### PR TITLE
Use MySQLi instead of MySQL for PHP7

### DIFF
--- a/admin_comment.php
+++ b/admin_comment.php
@@ -23,14 +23,14 @@
 	include 'function.php';
 
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
   
 	include 'db.php';
 
   	if(!isset($_GET['assessment_id']) || !isset($_GET['user_id']))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	$assessment_id = (int) $_GET['assessment_id'];
 	$user_id = (int) $_GET['user_id'];
@@ -40,24 +40,24 @@
 	if(isset($_GET['admin_comment']))
 	{
 		if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-			error($PN.'12');
+			error($PN.'12', $con);
 
 		$admin_comment_tmp = strip_tags($_GET['admin_comment']);
-		$admin_comment = mysql_real_escape_string($admin_comment_tmp);
+		$admin_comment = mysqli_real_escape_string($con, $admin_comment_tmp);
 		$admin_comment = trim($admin_comment);
 
-		mysql_query("UPDATE assignment SET admin_comment='".$admin_comment."' WHERE assessment_id = ".$assessment_id." AND user_id = ".$user_id.";") or error($PN.'13');
+		mysqli_query($con, "UPDATE assignment SET admin_comment='".$admin_comment."' WHERE assessment_id = ".$assessment_id." AND user_id = ".$user_id.";") or error($PN.'13', $con);
 	}
 
-	$result = mysql_query("SELECT id, admin_comment FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id = ".$user_id.";") or error($PN.'14');
+	$result = mysqli_query($con, "SELECT id, admin_comment FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id = ".$user_id.";") or error($PN.'14', $con);
 
-	$row = mysql_fetch_array($result);
+	$row = mysqli_fetch_array($result);
 
 	$response['Result'] = 'OK';
 	$response['Record'] = $row;
 
 	echo json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/admin_comment_show.php
+++ b/admin_comment_show.php
@@ -23,34 +23,34 @@
 	include 'function.php';
 
 	if(!isset($_SESSION['user']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
   
 	include 'db.php';
 
   	if(!isset($_GET['assignment_id']))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	$assignment_id = (int) $_GET['assignment_id'];
 	$user_id = $_SESSION['id'];
 
-	$result = mysql_query("SELECT user_id FROM assignment WHERE id = ".$assignment_id.";") or error($PN.'12');
-	$array = mysql_fetch_array($result);
+	$result = mysqli_query($con, "SELECT user_id FROM assignment WHERE id = ".$assignment_id.";") or error($PN.'12', $con);
+	$array = mysqli_fetch_array($result);
 
 	if($array['user_id']!=$user_id)
-		error($PN.'13');
+		error($PN.'13', $con);
 
 	$response = array();
 
-	$result = mysql_query("SELECT id, admin_comment FROM assignment WHERE id = ".$assignment_id.";") or error($PN.'14');
-	$row = mysql_fetch_array($result);
+	$result = mysqli_query($con, "SELECT id, admin_comment FROM assignment WHERE id = ".$assignment_id.";") or error($PN.'14', $con);
+	$row = mysqli_fetch_array($result);
 
 	$response['Result'] = 'OK';
 	$response['Record'] = $row;
 
 	echo json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/assessment-show.php
+++ b/assessment-show.php
@@ -22,7 +22,7 @@
 	include "settings.php";
 	include "function.php";
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 	header('Content-Type: text/html; charset=utf-8');
 
@@ -31,15 +31,15 @@
 	$response = array();
 	$rows = array();
 
-	$result = mysql_query("SELECT id, assessment_name FROM assessment ORDER BY assessment_name") or error($PN.'11');
+	$result = mysqli_query($con, "SELECT id, assessment_name FROM assessment ORDER BY assessment_name") or error($PN.'11', $con);
 
-	while ($row = mysql_fetch_array($result))
+	while ($row = mysqli_fetch_array($result))
 	{
-		$result_count1 = mysql_query("SELECT COUNT(*) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$row['id'].")) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'12');
-		$array_count1 = mysql_fetch_array($result_count1);
+		$result_count1 = mysqli_query($con, "SELECT COUNT(*) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$row['id'].")) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'12', $con);
+		$array_count1 = mysqli_fetch_array($result_count1);
 
-		$result_count2 = mysql_query("SELECT COUNT(*) FROM assessment_rules WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$row['id'].");") or error($PN.'13');
-		$array_count2 = mysql_fetch_array($result_count2);
+		$result_count2 = mysqli_query($con, "SELECT COUNT(*) FROM assessment_rules WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$row['id'].");") or error($PN.'13', $con);
+		$array_count2 = mysqli_fetch_array($result_count2);
 
 		if($array_count1[0] != 0)
 		{
@@ -59,6 +59,6 @@
 
 	echo json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/assessment.php
+++ b/assessment.php
@@ -23,19 +23,19 @@
 
 	include 'function.php';
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 	header('Content-Type: text/html; charset=utf-8');
 
 	include 'db.php';
 
 	if(!isset($_GET["action"]))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	if($_GET["action"] != "list")
 	{
 		if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-			error($PN.'12');
+			error($PN.'12', $con);
 	}
 
 	if(($_GET["action"] == "create") || ($_GET["action"] == "update"))
@@ -43,18 +43,18 @@
 		if(isset($_POST["assessment_name"]) && isset($_POST["description"]))
 		{
 			$assessment_name_tmp = strip_tags($_POST['assessment_name']);
-			$assessment_name = mysql_real_escape_string($assessment_name_tmp);
+			$assessment_name = mysqli_real_escape_string($con, $assessment_name_tmp);
 			$assessment_name = trim($assessment_name);
 
 			$description_tmp = strip_tags($_POST['description']);
-			$description = mysql_real_escape_string($description_tmp);
+			$description = mysqli_real_escape_string($con, $description_tmp);
 			$description = trim($description);
 
 			if(empty($assessment_name))
-				error($PN.'13');
+				error($PN.'13', $con);
 		}
 		else
-			error($PN.'14');	
+			error($PN.'14', $con);
 	}
 
 	if(($_GET["action"] == "update") || ($_GET["action"] == "delete"))
@@ -64,7 +64,7 @@
 			$id = (int)$_POST['id'];
 		}
 		else
-			error($PN.'15');
+			error($PN.'15', $con);
 	}
 
 	if($_GET["action"] == "list")
@@ -84,7 +84,7 @@
 					$sort .= ', ';
 
 				if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-					error($PN.'16');
+					error($PN.'16', $con);
 
 				switch ($Sorting_array[0]) {
 					case "assessment_name":
@@ -106,7 +106,7 @@
 						$sort .= 'A.complete_time';
 						break;
 					default:
-						error($PN.'17');
+						error($PN.'17', $con);
 				}
 					
 				if($Sorting_array[1] == 'ASC')
@@ -122,7 +122,7 @@
 			$PageSize = (int)$_GET['jtPageSize'];
 		}
 		else
-			error($PN.'18');
+			error($PN.'18', $con);
 
 		if(isset($_GET["select"]))
 			$select = (int)$_GET['select'];
@@ -131,26 +131,26 @@
 
 		if($select == 0)
 		{
-			$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM assessment;") or error($PN.'19');
-			$row = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM assessment;") or error($PN.'19', $con);
+			$row = mysqli_fetch_array($result);
 			$recordCount = $row['RecordCount'];
 
-			$result = mysql_query("SELECT A.id, B.uname, A.assessment_name, A.description, A.complete, A.create_time, A.complete_time FROM (SELECT * FROM assessment) AS A left join (SELECT id, uname FROM users) AS B on A.user_id=B.id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'20');
+			$result = mysqli_query($con, "SELECT A.id, B.uname, A.assessment_name, A.description, A.complete, A.create_time, A.complete_time FROM (SELECT * FROM assessment) AS A left join (SELECT id, uname FROM users) AS B on A.user_id=B.id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'20', $con);
 		}
 		else
 		{
 			$recordCount = 1;
-			$result = mysql_query("SELECT A.id, B.uname, A.assessment_name, A.description, A.complete, A.create_time, A.complete_time FROM (SELECT * FROM assessment WHERE id=".$select.") AS A left join (SELECT id, uname FROM users) AS B on A.user_id=B.id;") or error($PN.'21');
+			$result = mysqli_query($con, "SELECT A.id, B.uname, A.assessment_name, A.description, A.complete, A.create_time, A.complete_time FROM (SELECT * FROM assessment WHERE id=".$select.") AS A left join (SELECT id, uname FROM users) AS B on A.user_id=B.id;") or error($PN.'21', $con);
 		}
 		
 		$rows = array();
-		while($row = mysql_fetch_array($result))
+		while($row = mysqli_fetch_array($result))
 		{
-			$result_count1 = mysql_query("SELECT COUNT(B.chapter_id) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$row['id'].")) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'32');
-			$array_count1 = mysql_fetch_array($result_count1);
+			$result_count1 = mysqli_query($con, "SELECT COUNT(B.chapter_id) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$row['id'].")) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'32', $con);
+			$array_count1 = mysqli_fetch_array($result_count1);
 
-			$result_count2 = mysql_query("SELECT COUNT(*) FROM assessment_rules WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$row['id'].");") or error($PN.'33');
-			$array_count2 = mysql_fetch_array($result_count2);
+			$result_count2 = mysqli_query($con, "SELECT COUNT(*) FROM assessment_rules WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$row['id'].");") or error($PN.'33', $con);
+			$array_count2 = mysqli_fetch_array($result_count2);
 
 			if($array_count1[0] != 0)
 			{
@@ -179,16 +179,16 @@
 	else if($_GET["action"] == "create")
 	{
 	
-		$result1 = mysql_query("SELECT assessment_name FROM assessment WHERE assessment_name = '".$assessment_name."';") or error($PN.'22');
-		$row1 = mysql_fetch_array($result1);
+		$result1 = mysqli_query($con, "SELECT assessment_name FROM assessment WHERE assessment_name = '".$assessment_name."';") or error($PN.'22', $con);
+		$row1 = mysqli_fetch_array($result1);
 		
 		if($row1)
-			error($PN.'23');
+			error($PN.'23', $con);
 	
-		mysql_query("INSERT INTO assessment(user_id, assessment_name, description, create_time) VALUES(".$_SESSION['id'].",'".$assessment_name."','".$description."', NOW());") or error($PN.'24');
+		mysqli_query($con, "INSERT INTO assessment(user_id, assessment_name, description, create_time) VALUES(".$_SESSION['id'].",'".$assessment_name."','".$description."', NOW());") or error($PN.'24', $con);
 
-		$result = mysql_query("SELECT id, user_id, assessment_name, description, create_time FROM assessment WHERE id = LAST_INSERT_ID();") or error($PN.'25');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT id, user_id, assessment_name, description, create_time FROM assessment WHERE id = LAST_INSERT_ID();") or error($PN.'25', $con);
+		$row = mysqli_fetch_array($result);
 
 		$response = array();
 		$response['Result'] = "OK";
@@ -198,10 +198,10 @@
 	else if($_GET["action"] == "update")
 	{
 
-		mysql_query("UPDATE assessment SET assessment_name='".$assessment_name."', description='".$description."' WHERE id = ".$id.";") or error($PN.'26');
+		mysqli_query($con, "UPDATE assessment SET assessment_name='".$assessment_name."', description='".$description."' WHERE id = ".$id.";") or error($PN.'26', $con);
 
-		$result = mysql_query("SELECT id, user_id, assessment_name, description, create_time FROM assessment WHERE id = ".$id.";") or error($PN.'27');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT id, user_id, assessment_name, description, create_time FROM assessment WHERE id = ".$id.";") or error($PN.'27', $con);
+		$row = mysqli_fetch_array($result);
 
 		$response = array();
 		$response['Result'] = "OK";
@@ -212,21 +212,21 @@
 	else if($_GET["action"] == "delete")
 	{		
 	
-		$result = mysql_query("SELECT COUNT(*) FROM assignment WHERE assessment_id = ".$id.";") or error($PN.'28');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT COUNT(*) FROM assignment WHERE assessment_id = ".$id.";") or error($PN.'28', $con);
+		$row = mysqli_fetch_array($result);
 		if($row[0] == 0)
 		{
-			mysql_query("DELETE FROM assessment WHERE id = ".$id. ";") or error($PN.'29');
+			mysqli_query($con, "DELETE FROM assessment WHERE id = ".$id. ";") or error($PN.'29', $con);
 		}
 		else
-			error($PN.'30');
+			error($PN.'30', $con);
 
 		$response = array();
 		$response['Result'] = "OK";
 		print json_encode($response);
 	}
 	else
-		error($PN.'31');
+		error($PN.'31', $con);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/assignment-show-chapter.php
+++ b/assignment-show-chapter.php
@@ -22,7 +22,7 @@
 	include "settings.php";
 	include "function.php";
 	if(!isset($_SESSION['user']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
   
@@ -32,31 +32,31 @@
 	$rows = array();
   
 	if(!isset($_GET['type']) || !isset($_GET['id']))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	$id = (int)$_GET['id'];
 
 	$type = (int)$_GET['type'];
 	
-	$result = mysql_query("SELECT user_id FROM assignment WHERE id = ".$id.";") or error($PN.'16');
-	$array = mysql_fetch_array($result);
+	$result = mysqli_query($con, "SELECT user_id FROM assignment WHERE id = ".$id.";") or error($PN.'16', $con);
+	$array = mysqli_fetch_array($result);
 
 	if($array['user_id']!=$_SESSION['id'])
-		error($PN.'17');
+		error($PN.'17', $con);
 
 	if($type == 0)
-		$result = mysql_query("SELECT id, chapter_name FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$id.");") or error($PN.'12');
+		$result = mysqli_query($con, "SELECT id, chapter_name FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$id.");") or error($PN.'12', $con);
 	else
-		$result = mysql_query("SELECT id, chapter_name FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$id." AND status=".$type.");") or error($PN.'13');
+		$result = mysqli_query($con, "SELECT id, chapter_name FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$id." AND status=".$type.");") or error($PN.'13', $con);
     
-	while ($row = mysql_fetch_array($result))
+	while ($row = mysqli_fetch_array($result))
 	{
 
-		$result_count1 = mysql_query("SELECT COUNT(*) FROM rules WHERE chapter_id = ".$row['id'].";") or error($PN.'14');
-		$result_count2 = mysql_query("SELECT COUNT(*) FROM assessment_rules WHERE assignment_id=".$id." AND rule_id IN (SELECT id FROM rules WHERE chapter_id = ".$row['id'].");") or error($PN.'15');
+		$result_count1 = mysqli_query($con, "SELECT COUNT(*) FROM rules WHERE chapter_id = ".$row['id'].";") or error($PN.'14', $con);
+		$result_count2 = mysqli_query($con, "SELECT COUNT(*) FROM assessment_rules WHERE assignment_id=".$id." AND rule_id IN (SELECT id FROM rules WHERE chapter_id = ".$row['id'].");") or error($PN.'15', $con);
 
-		$array_count1 = mysql_fetch_array($result_count1);		
-		$array_count2 = mysql_fetch_array($result_count2);
+		$array_count1 = mysqli_fetch_array($result_count1);
+		$array_count2 = mysqli_fetch_array($result_count2);
 
 		if($array_count1[0] != 0)
 		{
@@ -76,6 +76,6 @@
 
 	echo json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/assignment-show.php
+++ b/assignment-show.php
@@ -22,7 +22,7 @@
 	include "settings.php";
 	include "function.php";
 	if(!isset($_SESSION['user']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
   
@@ -32,23 +32,23 @@
 	$rows = array();
 
 	if(!isset($_GET['type']))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	$type = (int)$_GET['type'];
 
 	if($type == 0)
-		$result = mysql_query("SELECT A.id, A.assessment_id, B.assessment_name FROM (SELECT id, assessment_id FROM assignment WHERE user_id = ".$_SESSION['id'].") AS A left join (SELECT id, assessment_name FROM assessment) AS B on A.assessment_id=B.id ORDER BY B.assessment_name") or error($PN.'12');
+		$result = mysqli_query($con, "SELECT A.id, A.assessment_id, B.assessment_name FROM (SELECT id, assessment_id FROM assignment WHERE user_id = ".$_SESSION['id'].") AS A left join (SELECT id, assessment_name FROM assessment) AS B on A.assessment_id=B.id ORDER BY B.assessment_name") or error($PN.'12', $con);
 	else
-		$result = mysql_query("SELECT A.id, A.assessment_id, B.assessment_name FROM (SELECT id, assessment_id FROM assignment WHERE user_id = ".$_SESSION['id']." AND id IN (SELECT assignment_id FROM assignment_chapter WHERE status=".$type.")) AS A left join (SELECT id, assessment_name FROM assessment) AS B on A.assessment_id=B.id ORDER BY B.assessment_name") or error($PN.'13');
+		$result = mysqli_query($con, "SELECT A.id, A.assessment_id, B.assessment_name FROM (SELECT id, assessment_id FROM assignment WHERE user_id = ".$_SESSION['id']." AND id IN (SELECT assignment_id FROM assignment_chapter WHERE status=".$type.")) AS A left join (SELECT id, assessment_name FROM assessment) AS B on A.assessment_id=B.id ORDER BY B.assessment_name") or error($PN.'13', $con);
 
-    while ($row = mysql_fetch_array($result))
+    while ($row = mysqli_fetch_array($result))
     {
 		$assessment_id = $row['assessment_id'];
-		$result_count1 = mysql_query("SELECT COUNT(B.chapter_id) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE assignment_id = (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id=".$_SESSION['id'].")) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'14');
-		$array_count1 = mysql_fetch_array($result_count1);
+		$result_count1 = mysqli_query($con, "SELECT COUNT(B.chapter_id) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE assignment_id = (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id=".$_SESSION['id'].")) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'14', $con);
+		$array_count1 = mysqli_fetch_array($result_count1);
 
-		$result_count2 = mysql_query("SELECT COUNT(*) FROM assessment_rules WHERE assignment_id = (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id=".$_SESSION['id'].");") or error($PN.'15');
-		$array_count2 = mysql_fetch_array($result_count2);
+		$result_count2 = mysqli_query($con, "SELECT COUNT(*) FROM assessment_rules WHERE assignment_id = (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id=".$_SESSION['id'].");") or error($PN.'15', $con);
+		$array_count2 = mysqli_fetch_array($result_count2);
 
 		if($array_count1[0] != 0)
 		{
@@ -66,14 +66,14 @@
 	$response['Result'] = 'OK';
 	$response['Records'] = $rows;
 
-	$result_new_assignment = mysql_query("SELECT id FROM assignment WHERE user_id = ".$_SESSION['id']." AND id IN (SELECT assignment_id FROM assignment_chapter WHERE status=1)") or error($PN.'16');
-	if(mysql_fetch_array($result_new_assignment))
+	$result_new_assignment = mysqli_query($con, "SELECT id FROM assignment WHERE user_id = ".$_SESSION['id']." AND id IN (SELECT assignment_id FROM assignment_chapter WHERE status=1)") or error($PN.'16', $con);
+	if(mysqli_fetch_array($result_new_assignment))
 		$response['new_assignment'] = 'Yes';
 	else
 		$response['new_assignment'] = 'No';
 
 	echo json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/assignment.php
+++ b/assignment.php
@@ -23,14 +23,14 @@
 
 	include 'function.php';
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 	header('Content-Type: text/html; charset=utf-8');
 
 	include 'db.php';
 
 	if(!isset($_GET["action"]))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	if($_GET["action"] == "list")
 	{
@@ -39,7 +39,7 @@
 			$assessment_id = (int)$_GET['assessment_id'];
 		}
 		else
-			error($PN.'12');	
+			error($PN.'12', $con);
 
 		if(isset($_GET["jtSorting"]) && isset($_GET["jtStartIndex"]) && isset($_GET["jtPageSize"]))
 		{
@@ -56,7 +56,7 @@
 					$sort .= ', ';
 
 				if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-					error($PN.'13');
+					error($PN.'13', $con);
 
 				switch ($Sorting_array[0]) {
 					case "uname":
@@ -75,7 +75,7 @@
 						$sort .= 'E.assignment_time';
 						break;
 					default:
-						error($PN.'14');
+						error($PN.'14', $con);
 				}
 					
 				if($Sorting_array[1] == 'ASC')
@@ -91,22 +91,22 @@
 			$PageSize = (int)$_GET['jtPageSize'];
 		}
 		else
-			error($PN.'15');
+			error($PN.'15', $con);
 
-		$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM (SELECT D.chapter_id FROM (SELECT A.id FROM (SELECT id, user_id FROM assignment where assessment_id=".$assessment_id.") AS A left join (SELECT id FROM users) AS B on A.user_id=B.id) AS C left join (SELECT chapter_id, assignment_id from assignment_chapter) AS D on C.id=D.assignment_id) AS E left join (SELECT id from chapters) AS F on E.chapter_id=F.id;") or error($PN.'16');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM (SELECT D.chapter_id FROM (SELECT A.id FROM (SELECT id, user_id FROM assignment where assessment_id=".$assessment_id.") AS A left join (SELECT id FROM users) AS B on A.user_id=B.id) AS C left join (SELECT chapter_id, assignment_id from assignment_chapter) AS D on C.id=D.assignment_id) AS E left join (SELECT id from chapters) AS F on E.chapter_id=F.id;") or error($PN.'16', $con);
+		$row = mysqli_fetch_array($result);
 		$recordCount = $row['RecordCount'];
 
-		$result = mysql_query("SELECT E.id, E.user_id, E.uname, E.chapter_id, F.chapter_name, IF(E.status = 3, 1, 0) AS complete, E.assignment_time FROM (SELECT D.id, C.user_id, C.uname, D.chapter_id, D.status, D.assignment_time FROM (SELECT A.id, B.id AS user_id, B.uname FROM (SELECT id, user_id FROM assignment where assessment_id=".$assessment_id.") AS A left join (SELECT id, uname FROM users) AS B on A.user_id=B.id) AS C left join (SELECT id, chapter_id, assignment_id, status, assignment_time from assignment_chapter) AS D on C.id=D.assignment_id) AS E left join (SELECT id, chapter_name from chapters) AS F on E.chapter_id=F.id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'17');
+		$result = mysqli_query($con, "SELECT E.id, E.user_id, E.uname, E.chapter_id, F.chapter_name, IF(E.status = 3, 1, 0) AS complete, E.assignment_time FROM (SELECT D.id, C.user_id, C.uname, D.chapter_id, D.status, D.assignment_time FROM (SELECT A.id, B.id AS user_id, B.uname FROM (SELECT id, user_id FROM assignment where assessment_id=".$assessment_id.") AS A left join (SELECT id, uname FROM users) AS B on A.user_id=B.id) AS C left join (SELECT id, chapter_id, assignment_id, status, assignment_time from assignment_chapter) AS D on C.id=D.assignment_id) AS E left join (SELECT id, chapter_name from chapters) AS F on E.chapter_id=F.id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'17', $con);
 
 		$rows = array();
-		while($row = mysql_fetch_array($result))
+		while($row = mysqli_fetch_array($result))
 		{
-			$result_count1 = mysql_query("SELECT COUNT(*) FROM rules WHERE chapter_id = (SELECT chapter_id FROM assignment_chapter WHERE id=".$row['id'].");") or error($PN.'26');
-			$result_count2 = mysql_query("SELECT COUNT(*) FROM assessment_rules WHERE assignment_id = (SELECT assignment_id FROM assignment_chapter WHERE id=".$row['id'].") AND rule_id IN (SELECT id FROM rules WHERE chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE id=".$row['id']."));") or error($PN.'27');
+			$result_count1 = mysqli_query($con, "SELECT COUNT(*) FROM rules WHERE chapter_id = (SELECT chapter_id FROM assignment_chapter WHERE id=".$row['id'].");") or error($PN.'26', $con);
+			$result_count2 = mysqli_query($con, "SELECT COUNT(*) FROM assessment_rules WHERE assignment_id = (SELECT assignment_id FROM assignment_chapter WHERE id=".$row['id'].") AND rule_id IN (SELECT id FROM rules WHERE chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE id=".$row['id']."));") or error($PN.'27', $con);
 
-			$array_count1 = mysql_fetch_array($result_count1);		
-			$array_count2 = mysql_fetch_array($result_count2);
+			$array_count1 = mysqli_fetch_array($result_count1);
+			$array_count2 = mysqli_fetch_array($result_count2);
 
 			if($array_count1[0] != 0)
 			{
@@ -139,37 +139,37 @@
 			$id = (int)$_POST['id'];
 		}
 		else
-			error($PN.'18');
+			error($PN.'18', $con);
 
 		if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-			error($PN.'19');
+			error($PN.'19', $con);
 
-		$result = mysql_query("SELECT COUNT(*), assignment_id FROM assignment_chapter WHERE assignment_id = (SELECT assignment_id FROM assignment_chapter WHERE id=".$id.");") or error($PN.'20');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT COUNT(*), assignment_id FROM assignment_chapter WHERE assignment_id = (SELECT assignment_id FROM assignment_chapter WHERE id=".$id.");") or error($PN.'20', $con);
+		$row = mysqli_fetch_array($result);
 		
-		$result_chapter = mysql_query("SELECT chapter_id FROM assignment_chapter WHERE id = ".$id.";") or error($PN.'21');
-		$row_chapter = mysql_fetch_array($result_chapter);
+		$result_chapter = mysqli_query($con, "SELECT chapter_id FROM assignment_chapter WHERE id = ".$id.";") or error($PN.'21', $con);
+		$row_chapter = mysqli_fetch_array($result_chapter);
 
 		if($row_chapter)
 		{
-			$result = mysql_query("SELECT id FROM report_rules WHERE assignment_id = ".$row[1]. " AND rule_id IN (SELECT id FROM rules WHERE chapter_id = ".$row_chapter['chapter_id'].");") or error($PN.'28');
-			if(mysql_fetch_array($result))
-				error($PN.'29');
+			$result = mysqli_query($con, "SELECT id FROM report_rules WHERE assignment_id = ".$row[1]. " AND rule_id IN (SELECT id FROM rules WHERE chapter_id = ".$row_chapter['chapter_id'].");") or error($PN.'28', $con);
+			if(mysqli_fetch_array($result))
+				error($PN.'29', $con);
 
-			mysql_query("DELETE FROM assessment_rules WHERE assignment_id = ".$row[1]. " AND rule_id IN (SELECT id FROM rules WHERE chapter_id = ".$row_chapter['chapter_id'].");") or error($PN.'23');
+			mysqli_query($con, "DELETE FROM assessment_rules WHERE assignment_id = ".$row[1]. " AND rule_id IN (SELECT id FROM rules WHERE chapter_id = ".$row_chapter['chapter_id'].");") or error($PN.'23', $con);
 
-			mysql_query("DELETE FROM assignment_chapter WHERE id = ".$id.";") or error($PN.'22');
+			mysqli_query($con, "DELETE FROM assignment_chapter WHERE id = ".$id.";") or error($PN.'22', $con);
 			
 			if($row[0] == 1)
-				mysql_query("DELETE FROM assignment WHERE id = ".$row[1]. ";") or error($PN.'24');
+				mysqli_query($con, "DELETE FROM assignment WHERE id = ".$row[1]. ";") or error($PN.'24', $con);
 		}
 		$response = array();
 		$response['Result'] = "OK";
 		print json_encode($response);
 	}
 	else
-		error($PN.'25');
+		error($PN.'25', $con);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/assignment_save.php
+++ b/assignment_save.php
@@ -23,21 +23,21 @@
 
 	include 'function.php';
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 	header('Content-Type: text/html; charset=utf-8');
 
 	include 'db.php';
 
 	if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	if(isset($_GET["user_id"]) && isset($_GET["assessment_id"]) && isset($_GET["chapters_id"]))
 	{
 		$user_id = (int)$_GET['user_id'];		
 		$assessment_id = (int)$_GET['assessment_id'];
 		$chapters_id_tmp = strip_tags($_GET['chapters_id']);
-		$chapters_id = mysql_real_escape_string($chapters_id_tmp); 
+		$chapters_id = mysqli_real_escape_string($con, $chapters_id_tmp);
 		$chapters_id = trim($chapters_id);
 
 		$chapters_id_array = explode(",", $_GET['chapters_id']);
@@ -52,48 +52,48 @@
 		}
 
 		if((empty($chapters_id) && $chapters_id != 0) || (strpos($chapters_id, "null") !== false))
-			error($PN.'12');
+			error($PN.'12', $con);
 	}
 	else
-		error($PN.'13');
+		error($PN.'13', $con);
 		
 	$comment = false;
 	if(isset($_GET["admin_comment"]))
 	{
 		$admin_comment_tmp = strip_tags($_GET['admin_comment']);
-		$admin_comment = mysql_real_escape_string($admin_comment_tmp); 
+		$admin_comment = mysqli_real_escape_string($con, $admin_comment_tmp);
 		$admin_comment = trim($admin_comment);
 		$comment = true;
 	}
 
-	$result_user = mysql_query("SELECT id FROM assessment WHERE id = ".$assessment_id.";") or error($PN.'27');
-	$array_user = mysql_fetch_array($result_user);
+	$result_user = mysqli_query($con, "SELECT id FROM assessment WHERE id = ".$assessment_id.";") or error($PN.'27', $con);
+	$array_user = mysqli_fetch_array($result_user);
 	if(!$array_user)
-		error($PN.'28');
+		error($PN.'28', $con);
 
-	$result_user = mysql_query("SELECT id FROM users WHERE id = ".$user_id.";") or error($PN.'29');
-	$array_user = mysql_fetch_array($result_user);
+	$result_user = mysqli_query($con, "SELECT id FROM users WHERE id = ".$user_id.";") or error($PN.'29', $con);
+	$array_user = mysqli_fetch_array($result_user);
 	if(!$array_user)
-		error($PN.'30');
+		error($PN.'30', $con);
 
-	$result_user = mysql_query("SELECT id FROM chapters WHERE id IN (".$chapters_id.");") or error($PN.'31');
-	$array_user = mysql_fetch_array($result_user);
+	$result_user = mysqli_query($con, "SELECT id FROM chapters WHERE id IN (".$chapters_id.");") or error($PN.'31', $con);
+	$array_user = mysqli_fetch_array($result_user);
 	if(!$array_user)
-		error($PN.'32');
+		error($PN.'32', $con);
 
-	$result = mysql_query("SELECT id FROM assignment WHERE user_id=".$user_id." and assessment_id=".$assessment_id.";") or error($PN.'14');
+	$result = mysqli_query($con, "SELECT id FROM assignment WHERE user_id=".$user_id." and assessment_id=".$assessment_id.";") or error($PN.'14', $con);
   
-	$array = mysql_fetch_array($result);
+	$array = mysqli_fetch_array($result);
  
 	if(!$array)
 	{
 		if($comment == true)
-			mysql_query("insert into assignment (user_id, assessment_id, status, admin_comment) values (".$user_id.",".$assessment_id.",1,'".$admin_comment."');") or error($PN.'15');	  
+			mysqli_query($con, "insert into assignment (user_id, assessment_id, status, admin_comment) values (".$user_id.",".$assessment_id.",1,'".$admin_comment."');") or error($PN.'15', $con);
 		else
-			mysql_query("insert into assignment (user_id, assessment_id, status) values (".$user_id.",".$assessment_id.",1);") or error($PN.'16');	  
+			mysqli_query($con, "insert into assignment (user_id, assessment_id, status) values (".$user_id.",".$assessment_id.",1);") or error($PN.'16', $con);
 	
-		$result = mysql_query("SELECT id FROM assignment WHERE id = LAST_INSERT_ID();") or error($PN.'17');
-		$array = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT id FROM assignment WHERE id = LAST_INSERT_ID();") or error($PN.'17', $con);
+		$array = mysqli_fetch_array($result);
 		$assignment_id = $array['id'];
 	}
 	else
@@ -101,18 +101,18 @@
 		$assignment_id = $array['id'];
 
 		if($comment == true)
-			mysql_query("update assignment set admin_comment='".$admin_comment."' where id=".$assignment_id.";") or error($PN.'18');
+			mysqli_query($con, "update assignment set admin_comment='".$admin_comment."' where id=".$assignment_id.";") or error($PN.'18', $con);
 	}
 
 	if($chapters_id == 0)
 	{
-		$result_chapter = mysql_query("SELECT id FROM chapters;") or error($PN.'21');			
-		while($chapter_id = mysql_fetch_array($result_chapter))
+		$result_chapter = mysqli_query($con, "SELECT id FROM chapters;") or error($PN.'21', $con);
+		while($chapter_id = mysqli_fetch_array($result_chapter))
 		{
-			$result = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id = ".$assignment_id." and chapter_id = ".$chapter_id['id'].";") or error($PN.'22');
-			$array = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id = ".$assignment_id." and chapter_id = ".$chapter_id['id'].";") or error($PN.'22', $con);
+			$array = mysqli_fetch_array($result);
 			if(!$array)
-				mysql_query("insert into assignment_chapter (chapter_id, assignment_id, status, assignment_time) values (".$chapter_id['id'].",".$assignment_id.",1 , NOW());") or error($PN.'23');	  
+				mysqli_query($con, "insert into assignment_chapter (chapter_id, assignment_id, status, assignment_time) values (".$chapter_id['id'].",".$assignment_id.",1 , NOW());") or error($PN.'23', $con);
 		}
 	}
 	else
@@ -121,15 +121,15 @@
 		$chapters_id_array = explode(",", $chapters_id);
 		foreach ($chapters_id_array as $chapterID) {
 			$chapter_id = (int)$chapterID;
-			$result_chapter = mysql_query("SELECT COUNT(*) FROM chapters WHERE id = ".$chapter_id.";") or error($PN.'24');
-			$array_chapter = mysql_fetch_row($result_chapter);
+			$result_chapter = mysqli_query($con, "SELECT COUNT(*) FROM chapters WHERE id = ".$chapter_id.";") or error($PN.'24', $con);
+			$array_chapter = mysqli_fetch_row($con, $result_chapter);
 			if($array_chapter[0] == 1)
 			{
-				$result = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id = ".$assignment_id." and chapter_id = ".$chapter_id.";") or error($PN.'25');
-				$array = mysql_fetch_array($result);
+				$result = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id = ".$assignment_id." and chapter_id = ".$chapter_id.";") or error($PN.'25', $con);
+				$array = mysqli_fetch_array($result);
 				if(!$array)
 				{
-					mysql_query("insert into assignment_chapter (chapter_id, assignment_id, status, assignment_time) values (".$chapter_id.",".$assignment_id.",1 , NOW());") or error($PN.'26');	  
+					mysqli_query($con, "insert into assignment_chapter (chapter_id, assignment_id, status, assignment_time) values (".$chapter_id.",".$assignment_id.",1 , NOW());") or error($PN.'26', $con);
 					if($uncompleted_run == false)
 					{
 						uncompleted($assignment_id, $assessment_id);
@@ -144,15 +144,15 @@
 	{
 		global $PN;
 		//Change Completed to Uncompleted in assignment Table
-		mysql_query("update assignment set status=2 where id=".$assignment_id." and status=3;") or error($PN.'19');
+		mysqli_query($con, "update assignment set status=2 where id=".$assignment_id." and status=3;") or error($PN.'19', $con);
 
 		//Set Complete=0 in assessment Table
-		mysql_query("update assessment set complete=0, complete_time='0' where id=".$assessment_id." and complete=1;") or error($PN.'20');		
+		mysqli_query($con, "update assessment set complete=0, complete_time='0' where id=".$assessment_id." and complete=1;") or error($PN.'20', $con);
 	}
 	
 	$response = array();
 	$response['Result'] = "OK";
 	print json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/chapters.php
+++ b/chapters.php
@@ -23,7 +23,7 @@
 	include "function.php";
 
 	if(!isset($_SESSION['user']))
-		error($PN.'10');
+		error($PN.'10', $con);
 		
 	header('Content-Type: text/html; charset=utf-8');
 
@@ -32,9 +32,9 @@
 	$response = array();
 	$rows = array();
 
-	$result = mysql_query("SELECT id, chapter_name FROM chapters order by id") or error($PN.'11');
+	$result = mysqli_query($con, "SELECT id, chapter_name FROM chapters order by id") or error($PN.'11', $con);
   
-	while ($row = mysql_fetch_array($result))
+	while ($row = mysqli_fetch_array($result))
 	{
 		$rows[] = $row;
 	}   
@@ -44,6 +44,6 @@
 
 	echo json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/chapters_assigned.php
+++ b/chapters_assigned.php
@@ -22,14 +22,14 @@
 	include "settings.php";
 	include "function.php";
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 	header('Content-Type: text/html; charset=utf-8');
 	
 	include 'db.php';
 
 	if(!isset($_GET['users_id']) || !isset($_GET['assessment_id']))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	$assessment_id = (int) $_GET['assessment_id'];
 
@@ -49,26 +49,26 @@
 
 	if($users_id==0)
 	{
-		$result = mysql_query("SELECT id, chapter_name FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id.")) ORDER BY id") or error($PN.'12');
+		$result = mysqli_query($con, "SELECT id, chapter_name FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id.")) ORDER BY id") or error($PN.'12', $con);
 	}
 	else
-		$result = mysql_query("SELECT id, chapter_name FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." and user_id IN (".$users_id."))) ORDER BY id") or error($PN.'13');
+		$result = mysqli_query($con, "SELECT id, chapter_name FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." and user_id IN (".$users_id."))) ORDER BY id") or error($PN.'13', $con);
   
-	while ($row = mysql_fetch_array($result))
+	while ($row = mysqli_fetch_array($result))
 	{
 		if($users_id==0)
 		{
-			$result_count1 = mysql_query("SELECT COUNT(*) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE chapter_id=".$row['id']." AND assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id.")) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'14');
-			$result_count2 = mysql_query("SELECT COUNT(*) FROM assessment_rules WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id.") AND rule_id IN (SELECT id FROM rules WHERE chapter_id=".$row['id'].");") or error($PN.'15');
+			$result_count1 = mysqli_query($con, "SELECT COUNT(*) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE chapter_id=".$row['id']." AND assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id.")) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'14', $con);
+			$result_count2 = mysqli_query($con, "SELECT COUNT(*) FROM assessment_rules WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id.") AND rule_id IN (SELECT id FROM rules WHERE chapter_id=".$row['id'].");") or error($PN.'15', $con);
 		}
 		else
 		{
-			$result_count1 = mysql_query("SELECT COUNT(*) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE chapter_id=".$row['id']." AND assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id IN (".$users_id."))) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'16');
-			$result_count2 = mysql_query("SELECT COUNT(*) FROM assessment_rules WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id IN (".$users_id.")) AND rule_id IN (SELECT id FROM rules WHERE chapter_id=".$row['id'].");") or error($PN.'17');
+			$result_count1 = mysqli_query($con, "SELECT COUNT(*) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE chapter_id=".$row['id']." AND assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id IN (".$users_id."))) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'16', $con);
+			$result_count2 = mysqli_query($con, "SELECT COUNT(*) FROM assessment_rules WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id IN (".$users_id.")) AND rule_id IN (SELECT id FROM rules WHERE chapter_id=".$row['id'].");") or error($PN.'17', $con);
 		}
 
-		$array_count1 = mysql_fetch_array($result_count1);		
-		$array_count2 = mysql_fetch_array($result_count2);
+		$array_count1 = mysqli_fetch_array($result_count1);
+		$array_count2 = mysqli_fetch_array($result_count2);
 
 		if($array_count1[0] != 0)
 		{
@@ -88,6 +88,6 @@
 
 	echo json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/db.php
+++ b/db.php
@@ -6,7 +6,6 @@ $pass = '';
 
 $databaseName = 'asvs2014';
 
-$con = mysql_connect($host,$user,$pass);
-$dbs = mysql_select_db($databaseName, $con) or error($PN.'10');
+$con = mysqli_connect($host,$user,$pass,$databaseName) or error($PN.'10');
 
 ?>

--- a/function.php
+++ b/function.php
@@ -156,7 +156,8 @@
 		return $string;
 	}
 
-	function error($error_number)
+	// $con is only null if an error occurred during the connection
+	function error($error_number, $con = null)
 	{
 		$PageNumber = substr($error_number, 0, 2);
 		$ErrorNumber = substr($error_number, 2);
@@ -165,7 +166,8 @@
 		$response['Message'] = message_get($PageNumber, $ErrorNumber);
 		print json_encode($response);
 
-		@mysql_close();
+
+		$con && @mysqli_close($con);
 		
 		exit();
 	}
@@ -721,7 +723,7 @@
 			return '#'.$PageNumber.$ErrorNumber.' - An Unknown Error Has Been Occurred.';
 	}
 	
-	function log_save($user_id, $action, $data)
+	function log_save($user_id, $action, $data, $con)
 	{
 		$ip = $_SERVER['REMOTE_ADDR'];
 
@@ -734,6 +736,6 @@
 			}
 		}
 
-		mysql_query("INSERT INTO logging(user_id, ip, data, time, action) VALUES(".$user_id.",'".$ip."', '".$data_save."', NOW(),".$action.");") or error('4410');
+		mysqli_query($con, "INSERT INTO logging(user_id, ip, data, time, action) VALUES(".$user_id.",'".$ip."', '".$data_save."', NOW(),".$action.");") or error('4410', $con);
 	}
 ?>

--- a/install/install.php
+++ b/install/install.php
@@ -31,12 +31,12 @@
 \$sc = '".$sc."'; //Security Code.
 \$time = '".$time."';//It is valid for 10 minutes.
 ?>");
-		error($PN.'10');
+		error($PN.'10', $con);
 	}
 
 
 	if(!isset($_POST['sc']) || ($_POST['sc'] != $sc))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	$response = array();
 
@@ -52,15 +52,15 @@
 		$databaseName = $_POST['db'];//Database Name
 
 		if(empty($host) || empty($user) || empty($databaseName))
-			error($PN.'12');
+			error($PN.'12', $con);
 
-		$con = mysql_connect($host,$user,$pass);
+		$con = mysqli_connect($host,$user,$pass,$databaseName);
 		if(!$con)
 			error($PN.'23');
 
-		mysql_query("CREATE DATABASE ".$databaseName);
+		mysqli_query($con, "CREATE DATABASE IF NOT EXISTS ".$databaseName);
 
-		@mysql_close($con);	
+		@mysqli_close($con);
 
 		try
 		{
@@ -76,7 +76,7 @@
 		}
 		catch(PDOException $ex)
 		{
-			error($PN.'24');
+			error($PN.'24', $con);
 		}
 		
 		if($response['Result'] == "OK")
@@ -91,8 +91,7 @@
 
 \$databaseName = '".$databaseName."';
 
-\$con = mysql_connect(\$host,\$user,\$pass);
-\$dbs = mysql_select_db(\$databaseName, \$con) or error(\$PN.'10');
+\$con = mysqli_connect(\$host,\$user,\$pass,\$databaseName) or error(\$PN.'10');
 
 ?>");
 
@@ -105,7 +104,7 @@
 		$logo = $_POST['logo'];//Logo
 
 		if(empty($organization_name) || empty($organization_address) || empty($logo))
-			error($PN.'12');
+			error($PN.'12', $con);
 
 		//Write to The db.php File
 		file_put_contents("../certificate/config.php","<?php
@@ -125,57 +124,57 @@
 		if(isset($_POST["fname"]) && isset($_POST["lname"]) && isset($_POST["email"]) && isset($_POST["password"]) && isset($_POST["uname"]))
 		{
 			$fname_tmp = strip_tags($_POST['fname']);
-			$fname = mysql_real_escape_string($fname_tmp);
+			$fname = mysqli_real_escape_string($con, $fname_tmp);
 			$fname = trim($fname);
 
 			$lname_tmp = strip_tags($_POST['lname']);
-			$lname = mysql_real_escape_string($lname_tmp);
+			$lname = mysqli_real_escape_string($con, $lname_tmp);
 			$lname = trim($lname);
 
 			$email_tmp = strip_tags($_POST['email']);
-			$email = mysql_real_escape_string($email_tmp);
+			$email = mysqli_real_escape_string($con, $email_tmp);
 			$email = trim($email);
 	
 			$password_tmp = strip_tags($_POST['password']);
-			$password = mysql_real_escape_string($password_tmp);
+			$password = mysqli_real_escape_string($con, $password_tmp);
 			$password = trim($password);
 			
 			$uname_tmp = strip_tags($_POST['uname']);
-			$uname = mysql_real_escape_string($uname_tmp);
+			$uname = mysqli_real_escape_string($con, $uname_tmp);
 			$uname = trim($uname);
 
 			if(empty($fname) || empty($lname) || empty($email) || empty($password) || empty($uname))
-				error($PN.'13');
+				error($PN.'13', $con);
 				
 			if (!preg_match("/([\w\-]+\@[\w\-]+\.[\w\-]+)/", $email))
-				error($PN.'14');
+				error($PN.'14', $con);
 				
 			if(strlen($password) < 6)
-				error($PN.'15');
+				error($PN.'15', $con);
 		}
 		else
-			error($PN.'16');
+			error($PN.'16', $con);
 			
-		$result_exists = mysql_query("SELECT uname FROM users WHERE uname = '".$uname."' and id != 1;") or error($PN.'17');
-		$row_exists = mysql_fetch_array($result_exists);
+		$result_exists = mysqli_query($con, "SELECT uname FROM users WHERE uname = '".$uname."' and id != 1;") or error($PN.'17', $con);
+		$row_exists = mysqli_fetch_array($result_exists);
 
 		if($row_exists)
-			error($PN.'18');
+			error($PN.'18', $con);
 
-		$result1 = mysql_query("SELECT * FROM users where id = 1") or error($PN.'19');
-		$row1 = mysql_fetch_array($result1);
+		$result1 = mysqli_query($con, "SELECT * FROM users where id = 1") or error($PN.'19', $con);
+		$row1 = mysqli_fetch_array($result1);
 
 		if($row1)
 		{
-			mysql_query("UPDATE users SET fname='".$fname."', lname='".$lname."', email='".$email."', uname='".$uname."', password='".sha1($password)."', administrator=1, enabled=1 WHERE id = 1;") or error($PN.'20');
+			mysqli_query($con, "UPDATE users SET fname='".$fname."', lname='".$lname."', email='".$email."', uname='".$uname."', password='".sha1($password)."', administrator=1, enabled=1 WHERE id = 1;") or error($PN.'20', $con);
 		}
 		else
 		{
-			mysql_query("INSERT INTO users(id, fname, lname, email, uname, password, administrator, enabled) VALUES(1,'".$fname."','".$lname."','".$email."','".$uname."','".sha1($password) ."',1,1)") or error($PN.'21');
+			mysqli_query($con, "INSERT INTO users(id, fname, lname, email, uname, password, administrator, enabled) VALUES(1,'".$fname."','".$lname."','".$email."','".$uname."','".sha1($password) ."',1,1)") or error($PN.'21', $con);
 		}
 
 		$response['Result'] = "OK";
-		@mysql_close();
+		@mysqli_close($con);
 
 	}
 	else if($_GET['action'] == "delete")//Delete Installation Directory
@@ -188,7 +187,7 @@
 		}
 	}
 	else
-		error($PN.'22');
+		error($PN.'22', $con);
 
 	function delete_installation_directory($dir)
 	{

--- a/install/sc.php
+++ b/install/sc.php
@@ -1,4 +1,4 @@
 <?php
 $sc = 'r710oo9fjyxwxi2l8ohmzocspz3dkk'; //Security Code.
-$time = '1411455651';//It is valid for 10 minutes.
+$time = '1540992527';//It is valid for 10 minutes.
 ?>

--- a/logging.php
+++ b/logging.php
@@ -23,14 +23,14 @@
 
 	include 'function.php';
     if(!isset($_SESSION['admin']))
-      error($PN.'10');
+      error($PN.'10', $con);
 	
     header('Content-Type: text/html; charset=utf-8');
 	
 	include 'db.php';
 	
 	if(!isset($_GET["action"]))
-	  error($PN.'11');
+	  error($PN.'11', $con);
 
 	if($_GET["action"] == "list")
 	{
@@ -49,7 +49,7 @@
 					$sort .= ', ';
 
 				if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-					error($PN.'12');
+					error($PN.'12', $con);
 
 				switch ($Sorting_array[0]) {
 					case "uname":
@@ -68,7 +68,7 @@
 						$sort .= 'action';
 						break;
 					default:
-						error($PN.'13');
+						error($PN.'13', $con);
 				}
 					
 				if($Sorting_array[1] == 'ASC')
@@ -84,7 +84,7 @@
 			$PageSize = (int)$_GET['jtPageSize'];
 		}
 		else
-			error($PN.'14');
+			error($PN.'14', $con);
 			
 	    if(isset($_GET["user_id"]))
 		  $user_id = (int)$_GET['user_id'];
@@ -95,13 +95,13 @@
 
 		if($user_id == 0)
 		{
-			$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM logging;") or error($PN.'15');
-			$row = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM logging;") or error($PN.'15', $con);
+			$row = mysqli_fetch_array($result);
 			$recordCount = $row['RecordCount'];
 
-			$result = mysql_query("SELECT C.id, C.uname, C.ip, C.data, C.time, D.action FROM (SELECT A.id, B.uname, A.ip, A.data, A.time, A.action FROM (SELECT id, user_id, ip, data, time, action FROM logging) AS A LEFT JOIN (SELECT id, uname FROM users) AS B ON A.user_id = B.id) AS C LEFT JOIN (SELECT id, action FROM logging_action) AS D ON C.action = D.id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'16');
+			$result = mysqli_query($con, "SELECT C.id, C.uname, C.ip, C.data, C.time, D.action FROM (SELECT A.id, B.uname, A.ip, A.data, A.time, A.action FROM (SELECT id, user_id, ip, data, time, action FROM logging) AS A LEFT JOIN (SELECT id, uname FROM users) AS B ON A.user_id = B.id) AS C LEFT JOIN (SELECT id, action FROM logging_action) AS D ON C.action = D.id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'16', $con);
 
-			while($row = mysql_fetch_array($result))
+			while($row = mysqli_fetch_array($result))
 			{
 				if($row['uname'] == '')
 					$row['uname'] = 'anonymous';
@@ -111,13 +111,13 @@
 		}
 		else
 		{
-			$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM logging WHERE user_id = ".$user_id.";") or error($PN.'23');
-			$row = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM logging WHERE user_id = ".$user_id.";") or error($PN.'23', $con);
+			$row = mysqli_fetch_array($result);
 			$recordCount = $row['RecordCount'];
 
-			$result = mysql_query("SELECT C.id, C.uname, C.ip, C.data, C.time, D.action FROM (SELECT A.id, B.uname, A.ip, A.data, A.time, A.action FROM (SELECT id, user_id, ip, data, time, action FROM logging WHERE user_id = ".$user_id.") AS A LEFT JOIN (SELECT id, uname FROM users WHERE id = ".$user_id.") AS B ON A.user_id = B.id) AS C LEFT JOIN (SELECT id, action FROM logging_action) AS D ON C.action = D.id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'17');
+			$result = mysqli_query($con, "SELECT C.id, C.uname, C.ip, C.data, C.time, D.action FROM (SELECT A.id, B.uname, A.ip, A.data, A.time, A.action FROM (SELECT id, user_id, ip, data, time, action FROM logging WHERE user_id = ".$user_id.") AS A LEFT JOIN (SELECT id, uname FROM users WHERE id = ".$user_id.") AS B ON A.user_id = B.id) AS C LEFT JOIN (SELECT id, action FROM logging_action) AS D ON C.action = D.id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'17', $con);
 
-			while($row = mysql_fetch_array($result))
+			while($row = mysqli_fetch_array($result))
 			{
 				$rows[] = $row;
 			}		
@@ -133,27 +133,27 @@
 	{
 	
 		if($_SESSION['id'] != 1)
-			error($PN.'22');
+			error($PN.'22', $con);
 
 		if($_GET["action"] != "list")
 			if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-				error($PN.'18');
+				error($PN.'18', $con);
 
 		if(isset($_POST['id']))
 		{
 			$id = (int)$_POST['id'];
 		}
 		else
-			error($PN.'19');
+			error($PN.'19', $con);
 
-		mysql_query("DELETE FROM logging WHERE id = ".$id.";") or error($PN.'20');
+		mysqli_query($con, "DELETE FROM logging WHERE id = ".$id.";") or error($PN.'20', $con);
 
 		$response = array();
 		$response['Result'] = "OK";
 		print json_encode($response);
 	}
 	else
-		error($PN.'21');
+		error($PN.'21', $con);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/login.php
+++ b/login.php
@@ -29,22 +29,21 @@
 	include 'db.php';
 
 	if(isset($_SESSION['user']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 		$response = array();
 
 	if(isset($_POST['uname']) && isset($_POST['password']) && !empty($_POST['uname']) && !empty($_POST['password']))
 	{
-		$uname = mysql_real_escape_string($_POST['uname']);
-		$password = mysql_real_escape_string($_POST['password']);
+		$uname = mysqli_real_escape_string($con, $_POST['uname']);
+		$password = mysqli_real_escape_string($con, $_POST['password']);
 	
-		$result = mysql_query("SELECT id, uname, administrator FROM users WHERE uname='".$uname."' AND password='".sha1($password)."' AND enabled=1") or error($PN.'11');
+		$result = mysqli_query($con, "SELECT id, uname, administrator FROM users WHERE uname='".$uname."' AND password='".sha1($password)."' AND enabled=1") or error($PN.'11', $con);
   
-		$array = mysql_fetch_array($result);
+		$array = mysqli_fetch_array($result);
 
 		if($array)
 		{
-
 			$response['Result'] = 'OK';
 			
 			$_SESSION['user']= $array["uname"];
@@ -56,25 +55,25 @@
 			$_SESSION['token'] = mt_rand_str(30);
 
 			$data['uname'] = $uname;
-			log_save($array["id"], 1, $data);
+			log_save($array["id"], 1, $data, $con);
 		}
 		else
 		{
 			$data['uname'] = $uname;
-			log_save(0, 2, $data);
-			error($PN.'12');
+			log_save(0, 2, $data, $con);
+			error($PN.'12', $con);
 		}
 	}
 	else
-		error($PN.'13');
+		error($PN.'13', $con);
 	
 	print json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 	
-	function log_login($user_id, $uname, $ip, $status)
+	function log_login($user_id, $uname, $ip, $status, $con)
 	{
 		global $PN;
-		mysql_query("INSERT INTO logging(user_id, ip, data, time, action) VALUES(".$user_id.", '".$ip."', '[uname=".$uname."]', NOW(),".$status.");") or error($PN.'14');
+		mysqli_query($con, "INSERT INTO logging(user_id, ip, data, time, action) VALUES(".$user_id.", '".$ip."', '[uname=".$uname."]', NOW(),".$status.");") or error($PN.'14', $con);
 	}
 ?>

--- a/logout.php
+++ b/logout.php
@@ -27,11 +27,11 @@
 	if(isset($_SESSION['user']))
 	{
 		if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-			error($PN.'10');
+			error($PN.'10', $con);
 
 		include 'db.php';
-		log_save($_SESSION['id'], 3, '');
-		@mysql_close();
+		log_save($_SESSION['id'], 3, '', $con);
+		@mysqli_close($con) ;
 
 		session_destroy();
 	}

--- a/methodology-action.php
+++ b/methodology-action.php
@@ -23,32 +23,32 @@
 
 	include 'function.php';
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
 	
 	include 'db.php';
 	
 	if(!isset($_GET["action"]))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	if(($_GET["action"] == "update"))
 	{
 		if(isset($_POST["methodology"]))
 		{
 			$methodology_tmp = strip_tags($_POST['methodology']);
-			$methodology = mysql_real_escape_string($methodology_tmp);
+			$methodology = mysqli_real_escape_string($con, $methodology_tmp);
 			$methodology = trim($methodology);
 		}
 		else
-			error($PN.'12');		
+			error($PN.'12', $con);
 
 		if(isset($_POST['id']))
 		{
 			$id = (int)$_POST['id'];
 		}
 		else
-			error($PN.'13');
+			error($PN.'13', $con);
 	}
 
 	if($_GET["action"] == "list")
@@ -69,7 +69,7 @@
 					$sort .= ', ';
 
 				if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-					error($PN.'14');
+					error($PN.'14', $con);
 
 				switch ($Sorting_array[0]) {
 					case "chapter_id":
@@ -88,7 +88,7 @@
 						$sort .= 'methodology';
 						break;
 					default:
-						error($PN.'15');
+						error($PN.'15', $con);
 				}
 					
 				if($Sorting_array[1] == 'ASC')
@@ -104,7 +104,7 @@
 			$PageSize = (int)$_GET['jtPageSize'];
 		}
 		else
-			error($PN.'16');
+			error($PN.'16', $con);
 			
 		if(isset($_GET["select"]))
 			$select = (int)$_GET['select'];
@@ -113,28 +113,28 @@
 
 		if($select == 0)
 		{
-			$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM rules;") or error($PN.'17');
-			$row = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM rules;") or error($PN.'17', $con);
+			$row = mysqli_fetch_array($result);
 			$recordCount = $row['RecordCount'];
 
-			$result = mysql_query("SELECT id, chapter_id, rule_number, title, level, methodology FROM rules ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'18');
+			$result = mysqli_query($con, "SELECT id, chapter_id, rule_number, title, level, methodology FROM rules ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'18', $con);
 
 			$rows = array();
-			while($row = mysql_fetch_array($result))
+			while($row = mysqli_fetch_array($result))
 			{
 				$rows[] = $row;
 			}
 		}
 		else
 		{
-			$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM rules where chapter_id=".$select.";") or error($PN.'19');
-			$row = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM rules where chapter_id=".$select.";") or error($PN.'19', $con);
+			$row = mysqli_fetch_array($result);
 			$recordCount = $row['RecordCount'];
 
-			$result = mysql_query("SELECT id, chapter_id, rule_number, title, level, methodology FROM rules where chapter_id=".$select." ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'20');
+			$result = mysqli_query($con, "SELECT id, chapter_id, rule_number, title, level, methodology FROM rules where chapter_id=".$select." ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'20', $con);
 
 			$rows = array();
-			while($row = mysql_fetch_array($result))
+			while($row = mysqli_fetch_array($result))
 			{
 				$rows[] = $row;
 			}		
@@ -150,12 +150,12 @@
 	{
 	
 		if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-			error($PN.'21');
+			error($PN.'21', $con);
 
-		mysql_query("UPDATE rules SET methodology='".$methodology."' WHERE id = ".$id.";") or error($PN.'22');
+		mysqli_query($con, "UPDATE rules SET methodology='".$methodology."' WHERE id = ".$id.";") or error($PN.'22', $con);
 
-		$result = mysql_query("SELECT id, methodology FROM rules WHERE id = ".$id.";") or error($PN.'23');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT id, methodology FROM rules WHERE id = ".$id.";") or error($PN.'23', $con);
+		$row = mysqli_fetch_array($result);
 
 		$response = array();
 		$response['Result'] = "OK";
@@ -164,7 +164,7 @@
 
 	}
 	else
-		error($PN.'24');
+		error($PN.'24', $con);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/report.php
+++ b/report.php
@@ -23,14 +23,14 @@
 
 	include 'function.php';
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 	header('Content-Type: text/html; charset=utf-8');
 
 	include 'db.php';
 
 	if(!isset($_GET["action"]))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	if($_GET["action"] == "list")
 	{
@@ -49,7 +49,7 @@
 					$sort .= ', ';
 
 				if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-					error($PN.'12');
+					error($PN.'12', $con);
 
 				switch ($Sorting_array[0])
 				{
@@ -60,7 +60,7 @@
 						$sort .= 'description';
 						break;
 					default:
-						error($PN.'13');
+						error($PN.'13', $con);
 				}
 						
 				if($Sorting_array[1] == 'ASC')
@@ -76,24 +76,24 @@
 			$PageSize = (int)$_GET['jtPageSize'];
 		}
 		else
-			error($PN.'14');
+			error($PN.'14', $con);
 
-		$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM assessment WHERE id IN (SELECT assessment_id FROM assignment WHERE id IN (SELECT assignment_id FROM report_rules)) ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'15');
-		$result2 = mysql_query("SELECT id, assessment_name, description FROM assessment WHERE id IN (SELECT assessment_id FROM assignment WHERE id IN (SELECT assignment_id FROM report_rules)) ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'16');
+		$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM assessment WHERE id IN (SELECT assessment_id FROM assignment WHERE id IN (SELECT assignment_id FROM report_rules)) ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'15', $con);
+		$result2 = mysqli_query($con, "SELECT id, assessment_name, description FROM assessment WHERE id IN (SELECT assessment_id FROM assignment WHERE id IN (SELECT assignment_id FROM report_rules)) ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'16', $con);
 
-		$row = mysql_fetch_array($result);
+		$row = mysqli_fetch_array($result);
 		$recordCount = $row['RecordCount'];
 
 		$rows = array();
-		while($row = mysql_fetch_array($result2))
+		while($row = mysqli_fetch_array($result2))
 		{
 
 			$assessment_id = $row['id'];
-			$result_count1 = mysql_query("SELECT COUNT(*) FROM rules WHERE chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id."));") or error($PN.'17');
-			$array_count1 = mysql_fetch_array($result_count1);
+			$result_count1 = mysqli_query($con, "SELECT COUNT(*) FROM rules WHERE chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id."));") or error($PN.'17', $con);
+			$array_count1 = mysqli_fetch_array($result_count1);
 
-			$result_count2 = mysql_query("SELECT COUNT(DISTINCT rule_id) FROM report_rules WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id.");") or error($PN.'18');
-			$array_count2 = mysql_fetch_array($result_count2);
+			$result_count2 = mysqli_query($con, "SELECT COUNT(DISTINCT rule_id) FROM report_rules WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id.");") or error($PN.'18', $con);
+			$array_count2 = mysqli_fetch_array($result_count2);
 
 			if($array_count1[0] != 0)
 			{
@@ -124,23 +124,23 @@
 	{
 
 		if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-			error($PN.'19');
+			error($PN.'19', $con);
 
 		if(isset($_POST['id']))
 		{
 			$id = (int)$_POST['id'];
 		}
 		else
-			error($PN.'20');
+			error($PN.'20', $con);
 
-		mysql_query("DELETE FROM report_rules WHERE assignment_id IN (select id FROM assignment WHERE assessment_id = ".$id. ");") or error($PN.'21');
+		mysqli_query($con, "DELETE FROM report_rules WHERE assignment_id IN (select id FROM assignment WHERE assessment_id = ".$id. ");") or error($PN.'21', $con);
 
 		$response = array();
 		$response['Result'] = "OK";
 		print json_encode($response);
 	}
 	else
-		error($PN.'22');
+		error($PN.'22', $con);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/report_create_save.php
+++ b/report_create_save.php
@@ -23,14 +23,14 @@
 	include 'function.php';
 
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
 	
 	include 'db.php';
 
 	if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-			error($PN.'11');
+			error($PN.'11', $con);
 
 	$assessment_rules_id_unchecked = '';
 		
@@ -47,9 +47,9 @@
 		}
 	}
 	else
-		error($PN.'12');
+		error($PN.'12', $con);
 
-	mysql_query("DELETE FROM report_rules WHERE id IN (".$assessment_rules_id_unchecked.");") or error($PN.'13');
+	mysqli_query($con, "DELETE FROM report_rules WHERE id IN (".$assessment_rules_id_unchecked.");") or error($PN.'13', $con);
 
 
 	if(isset($_GET['assessment_rules_id']))
@@ -61,26 +61,26 @@
 			$AssessmentRulesID = trim($AssessmentRulesID);
 			$assessment_rules_id = (int)$AssessmentRulesID;
 			
-			$result = mysql_query("SELECT assignment_id, rule_id FROM assessment_rules WHERE id = ".$assessment_rules_id.";") or error($PN.'14');
-			$row = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT assignment_id, rule_id FROM assessment_rules WHERE id = ".$assessment_rules_id.";") or error($PN.'14', $con);
+			$row = mysqli_fetch_array($result);
 
 			if($row)
 			{
-				$result_report = mysql_query("SELECT id FROM report_rules WHERE assignment_id = ".$row['assignment_id']." AND rule_id = ".$row['rule_id'].";") or error($PN.'15');
-				$row_report = mysql_fetch_array($result_report);
+				$result_report = mysqli_query($con, "SELECT id FROM report_rules WHERE assignment_id = ".$row['assignment_id']." AND rule_id = ".$row['rule_id'].";") or error($PN.'15', $con);
+				$row_report = mysqli_fetch_array($result_report);
 			
 				if(!$row_report)
-					mysql_query("INSERT INTO report_rules (assignment_id, rule_id, PassOrFail, comment, last_modified) SELECT assessment_rules.assignment_id, assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment, assessment_rules.last_modified FROM assessment_rules WHERE assessment_rules.id = ".$assessment_rules_id.";") or error($PN.'16');
+					mysqli_query($con, "INSERT INTO report_rules (assignment_id, rule_id, PassOrFail, comment, last_modified) SELECT assessment_rules.assignment_id, assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment, assessment_rules.last_modified FROM assessment_rules WHERE assessment_rules.id = ".$assessment_rules_id.";") or error($PN.'16', $con);
 			}
 		}
 	}
 	else
-		error($PN.'17');
+		error($PN.'17', $con);
 
 	$response = array();
 	
 	$response['Result'] = "OK";
 	print json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/report_create_show.php
+++ b/report_create_show.php
@@ -23,14 +23,14 @@
 	include 'function.php';
 
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
 	
 	include 'db.php';
 
 	if(!isset($_GET['action']))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	if(isset($_GET["jtSorting"]) && isset($_GET["jtStartIndex"]) && isset($_GET["jtPageSize"]))
 	{
@@ -46,7 +46,7 @@
 				$sort .= ', ';
 
 			if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-				error($PN.'12');
+				error($PN.'12', $con);
 
 			switch ($Sorting_array[0]) {
 				case "chapter_id":
@@ -71,7 +71,7 @@
 					$sort .= 'H.last_modified';
 					break;
 				default:
-					error($PN.'13');
+					error($PN.'13', $con);
 			}
 				
 			if($Sorting_array[1] == 'ASC')
@@ -87,7 +87,7 @@
 		$PageSize = (int)$_GET['jtPageSize'];
 	}
 	else
-		error($PN.'14');
+		error($PN.'14', $con);
 	
 	$assessment_id = '';
 	$chapters_id = '';
@@ -99,10 +99,10 @@
 			$assessment_id = (int) $_GET["assessment_id"];
 		}
 		else
-			error($PN.'15');	
+			error($PN.'15', $con);
 	}
 	else
-		error($PN.'16');
+		error($PN.'16', $con);
 
 	if($_GET['action'] == "user" || $_GET['action'] == "chapter")
 	{
@@ -120,7 +120,7 @@
 			}
 		}
 		else
-			error($PN.'17');
+			error($PN.'17', $con);
 	}
 
 	if($_GET['action'] == "chapter")
@@ -140,35 +140,35 @@
 
 		}
 		else
-			error($PN.'18');
+			error($PN.'18', $con);
 	}
 	
 	if($_GET['action'] == "assessment")
 	{
-		$result_assignment_chapters_id = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id.");") or error($PN.'19');
+		$result_assignment_chapters_id = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id.");") or error($PN.'19', $con);
 	}
 	else if($_GET['action'] == "user")
 	{
 		if($users_id != 0)
-			$result_assignment_chapters_id = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id."));") or error($PN.'20');
+			$result_assignment_chapters_id = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id."));") or error($PN.'20', $con);
 		else
-			$result_assignment_chapters_id = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id ORDER BY id));") or error($PN.'21');
+			$result_assignment_chapters_id = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id ORDER BY id));") or error($PN.'21', $con);
 
 	}
 	else
 	{
 		if($users_id != 0 && $chapters_id != 0)
-			$result_assignment_chapters_id = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id.")) AND chapter_id IN (".$chapters_id.")") or error($PN.'22');
+			$result_assignment_chapters_id = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id.")) AND chapter_id IN (".$chapters_id.")") or error($PN.'22', $con);
 		else if($users_id != 0 && $chapters_id == 0)
-			$result_assignment_chapters_id = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id.")) AND chapter_id IN (SELECT id FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." and user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id)) ORDER BY id))") or error($PN.'23');
+			$result_assignment_chapters_id = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id.")) AND chapter_id IN (SELECT id FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." and user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id)) ORDER BY id))") or error($PN.'23', $con);
 		else if($users_id == 0 && $chapters_id != 0)
-			$result_assignment_chapters_id = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id ORDER BY id)) AND chapter_id IN (".$chapters_id.")") or error($PN.'24');
+			$result_assignment_chapters_id = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id ORDER BY id)) AND chapter_id IN (".$chapters_id.")") or error($PN.'24', $con);
 		else
-			$result_assignment_chapters_id = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id ORDER BY id)) AND chapter_id IN (SELECT id FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." and user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id)) ORDER BY id))") or error($PN.'25');
+			$result_assignment_chapters_id = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id ORDER BY id)) AND chapter_id IN (SELECT id FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." and user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id)) ORDER BY id))") or error($PN.'25', $con);
 	}
 
 	$assignment_chapters_id = '';
-	while($row_assignment_chapters_id = mysql_fetch_array($result_assignment_chapters_id))
+	while($row_assignment_chapters_id = mysqli_fetch_array($result_assignment_chapters_id))
 	{
 		if($row_assignment_chapters_id['id'] > 0)//It has value
 		{
@@ -180,25 +180,25 @@
 	}
 		
 	if($assignment_chapters_id == '')
-		error($PN.'26');
+		error($PN.'26', $con);
 
 	$response = array();
 	
-	$result_report_id = mysql_query("SELECT A.id AS report_rules_id, B.id AS assessment_rules_id FROM (SELECT id, assignment_id, rule_id FROM report_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS A LEFT JOIN (SELECT id, assignment_id, rule_id FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS B ON A.assignment_id = B.assignment_id AND A.rule_id = B.rule_id;") or error($PN.'27');
+	$result_report_id = mysqli_query($con, "SELECT A.id AS report_rules_id, B.id AS assessment_rules_id FROM (SELECT id, assignment_id, rule_id FROM report_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS A LEFT JOIN (SELECT id, assignment_id, rule_id FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS B ON A.assignment_id = B.assignment_id AND A.rule_id = B.rule_id;") or error($PN.'27', $con);
 	$rows_report_id = array();
-	while($row_report_id = mysql_fetch_array($result_report_id))
+	while($row_report_id = mysqli_fetch_array($result_report_id))
 	{
 		$rows_report_id[] = $row_report_id;
 	}
 
-	$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM (SELECT E.assignment_id, E.id FROM (SELECT A.assignment_id, B.id, B.chapter_id FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT assignment_id, rule_id FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id") or error($PN.'28');
-	$result2 = mysql_query("SELECT G.chapter_id, G.rule_number, G.title, G.uname, H.id, H.PassOrFail, H.comment, H.last_modified FROM (SELECT E.assignment_id, E.id, E.chapter_id, E.rule_number, E.title, F.uname FROM (SELECT A.assignment_id, B.id, B.chapter_id, B.rule_number, B.title FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT id, assignment_id, rule_id, PassOrFail, comment, last_modified FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'29');
+	$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM (SELECT E.assignment_id, E.id FROM (SELECT A.assignment_id, B.id, B.chapter_id FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT assignment_id, rule_id FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id") or error($PN.'28', $con);
+	$result2 = mysqli_query($con, "SELECT G.chapter_id, G.rule_number, G.title, G.uname, H.id, H.PassOrFail, H.comment, H.last_modified FROM (SELECT E.assignment_id, E.id, E.chapter_id, E.rule_number, E.title, F.uname FROM (SELECT A.assignment_id, B.id, B.chapter_id, B.rule_number, B.title FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT id, assignment_id, rule_id, PassOrFail, comment, last_modified FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'29', $con);
 
-	$row = mysql_fetch_array($result);
+	$row = mysqli_fetch_array($result);
 	$recordCount = $row['RecordCount'];
 
 	$rows = array();
-	while($row = mysql_fetch_array($result2))
+	while($row = mysqli_fetch_array($result2))
 	{
 		$row['selected'] = '0';
 		$row['report_rules_id'] = '0';
@@ -222,5 +222,5 @@
 
 	print json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/report_result.php
+++ b/report_result.php
@@ -23,7 +23,7 @@
 
 	include 'function.php';
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
 	
@@ -32,14 +32,14 @@
 	if(($_GET["action"] == "update") || ($_GET["action"] == "delete"))
 	{
 		if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-			error($PN.'11');
+			error($PN.'11', $con);
 
 		if(isset($_POST['id']))
 		{
 			$id = (int)$_POST['id'];
 		}
 		else
-			error($PN.'12');
+			error($PN.'12', $con);
 	}
 
 	if($_GET["action"] == "list")
@@ -49,7 +49,7 @@
 			$assessment_id = (int)$_GET['assessment_id'];
 		}
 		else
-			error($PN.'13');
+			error($PN.'13', $con);
 
 		if(isset($_GET["jtSorting"]) && isset($_GET["jtStartIndex"]) && isset($_GET["jtPageSize"]))
 		{
@@ -65,7 +65,7 @@
 					$sort .= ', ';
 
 				if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-					error($PN.'14');
+					error($PN.'14', $con);
 
 				switch ($Sorting_array[0]) {
 					case "chapter_id":
@@ -87,7 +87,7 @@
 						$sort .= 'last_modified';
 						break;
 					default:
-						error($PN.'15');
+						error($PN.'15', $con);
 				}
 					
 				if($Sorting_array[1] == 'ASC')
@@ -103,16 +103,16 @@
 			$PageSize = (int)$_GET['jtPageSize'];
 		}
 		else
-			error($PN.'16');
+			error($PN.'16', $con);
 
-		$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM (SELECT report_rules.assignment_id FROM report_rules WHERE report_rules.assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id.")) AS A left join (SELECT assignment.id FROM assignment WHERE assessment_id=".$assessment_id.") AS B on A.assignment_id=B.id") or error($PN.'17');
-		$result2 = mysql_query("SELECT E.id, E.PassOrFail, E.comment, E.last_modified, E.uname, F.chapter_id, F.rule_number, F.title FROM (SELECT C.id, C.rule_id, C.PassOrFail, C.comment, C.last_modified, D.uname FROM (SELECT A.id, A.rule_id, A.PassOrFail, A.comment, A.last_modified, B.user_id FROM (SELECT report_rules.id, report_rules.assignment_id, report_rules.rule_id, report_rules.PassOrFail, report_rules.comment, report_rules.last_modified FROM report_rules WHERE report_rules.assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id.")) AS A left join (SELECT assignment.id, assignment.user_id FROM assignment WHERE assessment_id=".$assessment_id.") AS B on A.assignment_id=B.id) AS C left join (SELECT users.id, users.uname FROM users) AS D on C.user_id=D.id) AS E left join (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title FROM rules) AS F on E.rule_id=F.id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'18');
+		$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM (SELECT report_rules.assignment_id FROM report_rules WHERE report_rules.assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id.")) AS A left join (SELECT assignment.id FROM assignment WHERE assessment_id=".$assessment_id.") AS B on A.assignment_id=B.id") or error($PN.'17', $con);
+		$result2 = mysqli_query($con, "SELECT E.id, E.PassOrFail, E.comment, E.last_modified, E.uname, F.chapter_id, F.rule_number, F.title FROM (SELECT C.id, C.rule_id, C.PassOrFail, C.comment, C.last_modified, D.uname FROM (SELECT A.id, A.rule_id, A.PassOrFail, A.comment, A.last_modified, B.user_id FROM (SELECT report_rules.id, report_rules.assignment_id, report_rules.rule_id, report_rules.PassOrFail, report_rules.comment, report_rules.last_modified FROM report_rules WHERE report_rules.assignment_id IN (SELECT id FROM assignment WHERE assessment_id=".$assessment_id.")) AS A left join (SELECT assignment.id, assignment.user_id FROM assignment WHERE assessment_id=".$assessment_id.") AS B on A.assignment_id=B.id) AS C left join (SELECT users.id, users.uname FROM users) AS D on C.user_id=D.id) AS E left join (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title FROM rules) AS F on E.rule_id=F.id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'18', $con);
 	
-		$row = mysql_fetch_array($result);
+		$row = mysqli_fetch_array($result);
 		$recordCount = $row['RecordCount'];
 
 		$rows = array();
-		while($row = mysql_fetch_array($result2))
+		while($row = mysqli_fetch_array($result2))
 		{
 			$rows[] = $row;
 		}		
@@ -133,16 +133,16 @@
 		if(isset($_POST['comment']))
 		{
 			$comment_tmp = strip_tags($_POST['comment']);
-			$comment = mysql_real_escape_string($comment_tmp); 		
+			$comment = mysqli_real_escape_string($con, $comment_tmp);
 			$comment = trim($comment);
 		}
 		else
-			error($PN.'19');	
+			error($PN.'19', $con);
 
-		mysql_query("update report_rules set PassOrFail='".$PassOrFail."', comment='".$comment."', last_modified= NOW() where id = ".$id.";") or error($PN.'20');
+		mysqli_query($con, "update report_rules set PassOrFail='".$PassOrFail."', comment='".$comment."', last_modified= NOW() where id = ".$id.";") or error($PN.'20', $con);
 
-		$result = mysql_query("SELECT id, comment FROM report_rules WHERE id = ".$id.";") or error($PN.'21');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT id, comment FROM report_rules WHERE id = ".$id.";") or error($PN.'21', $con);
+		$row = mysqli_fetch_array($result);
 
 		$response = array();
 		$response['Result'] = "OK";
@@ -152,14 +152,14 @@
 	}
 	else if($_GET["action"] == "delete")
 	{
-		mysql_query("DELETE FROM report_rules WHERE id = ".$id.";") or error($PN.'22');
+		mysqli_query($con, "DELETE FROM report_rules WHERE id = ".$id.";") or error($PN.'22', $con);
 
 		$response = array();
 		$response['Result'] = "OK";
 		print json_encode($response);
 	}
 	else
-		error($PN.'23');
+		error($PN.'23', $con);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/rules-action.php
+++ b/rules-action.php
@@ -23,18 +23,18 @@
 
 	include 'function.php';
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 	header('Content-Type: text/html; charset=utf-8');
 
 	include 'db.php';
 
 	if(!isset($_GET["action"]))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	if($_GET["action"] != "list")
 		if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-			error($PN.'12');
+			error($PN.'12', $con);
 
 	if(($_GET["action"] == "create") || ($_GET["action"] == "update"))
 	{
@@ -45,19 +45,19 @@
 			$rule_number = (int)$_POST['rule_number'];
 
 			$title_tmp = strip_tags($_POST['title']);
-			$title = mysql_real_escape_string($title_tmp);
+			$title = mysqli_real_escape_string($con, $title_tmp);
 			$title = trim($title);
 
 			$level = (int)$_POST['level'];
 			
 			if(!($level == 1 || $level == 2 || $level == 3))
-				error($PN.'59');
+				error($PN.'59', $con);
 
 			if(empty($chapter_id) || empty($rule_number) || empty($title) || empty($level))
-				error($PN.'13');
+				error($PN.'13', $con);
 		}
 		else
-			error($PN.'14');		
+			error($PN.'14', $con);
 	}
 
 	if(($_GET["action"] == "update") || ($_GET["action"] == "delete"))
@@ -67,7 +67,7 @@
 			$id = (int)$_POST['id'];
 		}
 		else
-			error($PN.'15');
+			error($PN.'15', $con);
 	}
 
 	if($_GET["action"] == "list")
@@ -88,7 +88,7 @@
 					$sort .= ', ';
 
 				if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-					error($PN.'16');
+					error($PN.'16', $con);
 
 				switch ($Sorting_array[0]) {
 					case "chapter_id":
@@ -104,7 +104,7 @@
 						$sort .= 'title';
 						break;
 					default:
-						error($PN.'17');
+						error($PN.'17', $con);
 				}
 					
 				if($Sorting_array[1] == 'ASC')
@@ -120,7 +120,7 @@
 			$PageSize = (int)$_GET['jtPageSize'];
 		}
 		else
-			error($PN.'18');
+			error($PN.'18', $con);
 			
 		if(isset($_GET["select"]))
 			$select = (int)$_GET['select'];
@@ -129,28 +129,28 @@
 
 		if($select == 0)
 		{
-			$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM rules;") or error($PN.'19');
-			$row = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM rules;") or error($PN.'19', $con);
+			$row = mysqli_fetch_array($result);
 			$recordCount = $row['RecordCount'];
 
-			$result = mysql_query("SELECT id, chapter_id, rule_number, title, level FROM rules ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'20');
+			$result = mysqli_query($con, "SELECT id, chapter_id, rule_number, title, level FROM rules ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'20', $con);
 
 			$rows = array();
-			while($row = mysql_fetch_array($result))
+			while($row = mysqli_fetch_array($result))
 			{
 				$rows[] = $row;
 			}
 		}
 		else
 		{
-			$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM rules where chapter_id=".$select.";") or error($PN.'21');
-			$row = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM rules where chapter_id=".$select.";") or error($PN.'21', $con);
+			$row = mysqli_fetch_array($result);
 			$recordCount = $row['RecordCount'];
 
-			$result = mysql_query("SELECT id, chapter_id, rule_number, title, level FROM rules where chapter_id=".$select." ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'22');
+			$result = mysqli_query($con, "SELECT id, chapter_id, rule_number, title, level FROM rules where chapter_id=".$select." ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'22', $con);
 
 			$rows = array();
-			while($row = mysql_fetch_array($result))
+			while($row = mysqli_fetch_array($result))
 			{
 				$rows[] = $row;
 			}		
@@ -164,24 +164,24 @@
 	}
 	else if($_GET["action"] == "create")
 	{
-		$result1 = mysql_query("SELECT * FROM chapters WHERE id = ".$chapter_id.";") or error($PN.'37');
-		$row1 = mysql_fetch_array($result1);
+		$result1 = mysqli_query($con, "SELECT * FROM chapters WHERE id = ".$chapter_id.";") or error($PN.'37', $con);
+		$row1 = mysqli_fetch_array($result1);
 		
 		if(!$row1)
-		  error($PN.'38');
+		  error($PN.'38', $con);
 
-		$result2 = mysql_query("SELECT id FROM rules WHERE chapter_id = ".$chapter_id." and rule_number = ".$rule_number.";") or error($PN.'23');
-		$row2 = mysql_fetch_array($result2);
+		$result2 = mysqli_query($con, "SELECT id FROM rules WHERE chapter_id = ".$chapter_id." and rule_number = ".$rule_number.";") or error($PN.'23', $con);
+		$row2 = mysqli_fetch_array($result2);
 		
 		if($row2)
-		  error($PN.'24');
+		  error($PN.'24', $con);
 		
-		mysql_query("INSERT INTO rules(chapter_id, rule_number, title, level) VALUES(".$chapter_id.",".$rule_number.",'".$title."',".$level.");") or error($PN.'25');
+		mysqli_query($con, "INSERT INTO rules(chapter_id, rule_number, title, level) VALUES(".$chapter_id.",".$rule_number.",'".$title."',".$level.");") or error($PN.'25', $con);
 
 		uncompleted($chapter_id);
 
-		$result = mysql_query("SELECT id, chapter_id, rule_number, title, level FROM rules WHERE id = LAST_INSERT_ID();") or error($PN.'26');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT id, chapter_id, rule_number, title, level FROM rules WHERE id = LAST_INSERT_ID();") or error($PN.'26', $con);
+		$row = mysqli_fetch_array($result);
 
 		$response = array();
 		$response['Result'] = "OK";
@@ -191,47 +191,47 @@
 	else if($_GET["action"] == "update")
 	{
 	
-		$result_chapter = mysql_query("SELECT * FROM chapters WHERE id = ".$chapter_id.";") or error($PN.'44');
-		$row_chapter = mysql_fetch_array($result_chapter);
+		$result_chapter = mysqli_query($con, "SELECT * FROM chapters WHERE id = ".$chapter_id.";") or error($PN.'44', $con);
+		$row_chapter = mysqli_fetch_array($result_chapter);
 		
 		if(!$row_chapter)
-		  error($PN.'45');
+		  error($PN.'45', $con);
 
-		$result1 = mysql_query("SELECT id FROM rules WHERE chapter_id = ".$chapter_id." AND rule_number = ".$rule_number." AND id != ".$id.";") or error($PN.'27');
-		$row1 = mysql_fetch_array($result1);
+		$result1 = mysqli_query($con, "SELECT id FROM rules WHERE chapter_id = ".$chapter_id." AND rule_number = ".$rule_number." AND id != ".$id.";") or error($PN.'27', $con);
+		$row1 = mysqli_fetch_array($result1);
 		
 		if($row1)
-		  error($PN.'28');
+		  error($PN.'28', $con);
 
-		$result = mysql_query("SELECT chapter_id FROM rules WHERE id = ".$id.";") or error($PN.'39');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT chapter_id FROM rules WHERE id = ".$id.";") or error($PN.'39', $con);
+		$row = mysqli_fetch_array($result);
 		
 		$chapter_id_changed = false;
 		if($row['chapter_id'] != $chapter_id)
 		{
-			$result = mysql_query("SELECT rule_id FROM assessment_rules WHERE rule_id = ".$id.";") or error($PN.'40');
-			if(mysql_fetch_array($result))
-				error($PN.'41');
+			$result = mysqli_query($con, "SELECT rule_id FROM assessment_rules WHERE rule_id = ".$id.";") or error($PN.'40', $con);
+			if(mysqli_fetch_array($result))
+				error($PN.'41', $con);
 			else
 			{
-				$result = mysql_query("SELECT rule_id FROM report_rules WHERE rule_id = ".$id.";") or error($PN.'42');
-				if(mysql_fetch_array($result))
-					error($PN.'43');
+				$result = mysqli_query($con, "SELECT rule_id FROM report_rules WHERE rule_id = ".$id.";") or error($PN.'42', $con);
+				if(mysqli_fetch_array($result))
+					error($PN.'43', $con);
 			}
 			
 			$chapter_id_changed = true;
 		}
 
-		mysql_query("UPDATE rules SET chapter_id=".$chapter_id.", rule_number=".$rule_number.", title='".$title."', level=".$level." WHERE id = ".$id.";") or error($PN.'29');
+		mysqli_query($con, "UPDATE rules SET chapter_id=".$chapter_id.", rule_number=".$rule_number.", title='".$title."', level=".$level." WHERE id = ".$id.";") or error($PN.'29', $con);
 
-		if(($chapter_id_changed == true) && (mysql_affected_rows() == 1))
+		if(($chapter_id_changed == true) && (mysqli_affected_rows($con)  == 1))
 		{
 			uncompleted($chapter_id);
 			iscompleted($row['chapter_id']);
 		}
 
-		$result = mysql_query("SELECT id, chapter_id, rule_number, title, level FROM rules WHERE id = ".$id.";") or error($PN.'30');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT id, chapter_id, rule_number, title, level FROM rules WHERE id = ".$id.";") or error($PN.'30', $con);
+		$row = mysqli_fetch_array($result);
 
 		$response = array();
 		$response['Result'] = "OK";
@@ -241,22 +241,22 @@
 	else if($_GET["action"] == "delete")
 	{
 
-		$result = mysql_query("SELECT rule_id FROM assessment_rules WHERE rule_id = ".$id.";") or error($PN.'31');
-		if(mysql_fetch_array($result))
-			error($PN.'32');
+		$result = mysqli_query($con, "SELECT rule_id FROM assessment_rules WHERE rule_id = ".$id.";") or error($PN.'31', $con);
+		if(mysqli_fetch_array($result))
+			error($PN.'32', $con);
 		else
 		{
-			$result = mysql_query("SELECT rule_id FROM report_rules WHERE rule_id = ".$id.";") or error($PN.'33');
-			if(mysql_fetch_array($result))
-				error($PN.'34');
+			$result = mysqli_query($con, "SELECT rule_id FROM report_rules WHERE rule_id = ".$id.";") or error($PN.'33', $con);
+			if(mysqli_fetch_array($result))
+				error($PN.'34', $con);
 		}
 
-		$result = mysql_query("SELECT chapter_id FROM rules WHERE id = ".$id.";") or error($PN.'49');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT chapter_id FROM rules WHERE id = ".$id.";") or error($PN.'49', $con);
+		$row = mysqli_fetch_array($result);
 		if($row['chapter_id'] == '')
-			error($PN.'60');			
+			error($PN.'60', $con);
 
-		mysql_query("DELETE FROM rules WHERE id = ".$id. ";") or error($PN.'35');
+		mysqli_query($con, "DELETE FROM rules WHERE id = ".$id. ";") or error($PN.'35', $con);
 
 		iscompleted($row['chapter_id']);
 
@@ -265,61 +265,61 @@
 		print json_encode($response);
 	}
 	else
-		error($PN.'36');
+		error($PN.'36', $con);
 
 	function uncompleted($chapter_id)
 	{
 		global $PN;
 		//Change Completed to Uncompleted in assignment_chapter Table
-		mysql_query("UPDATE assignment_chapter SET status=2 WHERE chapter_id=".$chapter_id.";") or error($PN.'46');
+		mysqli_query($con, "UPDATE assignment_chapter SET status=2 WHERE chapter_id=".$chapter_id.";") or error($PN.'46', $con);
 
 		//Change Completed to Uncompleted in assignment Table
-		mysql_query("UPDATE assignment SET status=2 WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE chapter_id=".$chapter_id.") AND status=3;") or error($PN.'47');
+		mysqli_query($con, "UPDATE assignment SET status=2 WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE chapter_id=".$chapter_id.") AND status=3;") or error($PN.'47', $con);
 
 		//Set Complete=0 in assessment Table
-		mysql_query("UPDATE assessment SET complete=0, complete_time='0' WHERE id IN (SELECT assessment_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE chapter_id=".$chapter_id.")) AND complete=1;") or error($PN.'48');
+		mysqli_query($con, "UPDATE assessment SET complete=0, complete_time='0' WHERE id IN (SELECT assessment_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE chapter_id=".$chapter_id.")) AND complete=1;") or error($PN.'48', $con);
 	}
 	
 	function iscompleted($chapter_id)
 	{
 		global $PN;
 		$rows = array();
-		$result = mysql_query("SELECT assignment_id FROM assignment_chapter WHERE chapter_id=".$chapter_id.";") or error($PN.'50');
-		while($row = mysql_fetch_array($result))
+		$result = mysqli_query($con, "SELECT assignment_id FROM assignment_chapter WHERE chapter_id=".$chapter_id.";") or error($PN.'50', $con);
+		while($row = mysqli_fetch_array($result))
 		{
 			$assignment_id = $row['assignment_id'];	
 		
-			$result_count1 = mysql_query("SELECT COUNT(*) FROM rules WHERE chapter_id =".$chapter_id.";") or error($PN.'51');
-			$array_count1 = mysql_fetch_array($result_count1);
+			$result_count1 = mysqli_query($con, "SELECT COUNT(*) FROM rules WHERE chapter_id =".$chapter_id.";") or error($PN.'51', $con);
+			$array_count1 = mysqli_fetch_array($result_count1);
 
-			$result_count2 = mysql_query("SELECT COUNT(*) FROM assessment_rules WHERE assignment_id=".$assignment_id." AND rule_id IN (SELECT id FROM rules WHERE chapter_id =".$chapter_id.");") or error($PN.'52');
-			$array_count2 = mysql_fetch_array($result_count2);
+			$result_count2 = mysqli_query($con, "SELECT COUNT(*) FROM assessment_rules WHERE assignment_id=".$assignment_id." AND rule_id IN (SELECT id FROM rules WHERE chapter_id =".$chapter_id.");") or error($PN.'52', $con);
+			$array_count2 = mysqli_fetch_array($result_count2);
 			
 			//Set status=3 in assignment_chapter Table
 			if($array_count1[0] == $array_count2[0])
 			{
-				mysql_query("UPDATE assignment_chapter SET status=3 WHERE assignment_id=".$assignment_id." AND chapter_id=".$chapter_id.";") or error($PN.'53');
+				mysqli_query($con, "UPDATE assignment_chapter SET status=3 WHERE assignment_id=".$assignment_id." AND chapter_id=".$chapter_id.";") or error($PN.'53', $con);
 			}
 
 			//Change Uncompleted to Completed in assignment Table
-			$result3 = mysql_query("SELECT COUNT(*) FROM assignment_chapter WHERE assignment_id=".$assignment_id." and status!=3;") or error($PN.'54');
-			$array3 = mysql_fetch_array($result3);
+			$result3 = mysqli_query($con, "SELECT COUNT(*) FROM assignment_chapter WHERE assignment_id=".$assignment_id." and status!=3;") or error($PN.'54', $con);
+			$array3 = mysqli_fetch_array($result3);
 			if($array3[0] == 0)
 			{
-				mysql_query("UPDATE assignment SET status=3 WHERE id=".$assignment_id." AND status=2;") or error($PN.'55');
+				mysqli_query($con, "UPDATE assignment SET status=3 WHERE id=".$assignment_id." AND status=2;") or error($PN.'55', $con);
 				$row['completed'] = 'Yes';
 			}
 
 			//Set Complete=1 in assessment Table
-			$result4 = mysql_query("SELECT assessment_id FROM assignment WHERE id=".$assignment_id.";") or error($PN.'56');
-			$array4 = mysql_fetch_array($result4);
+			$result4 = mysqli_query($con, "SELECT assessment_id FROM assignment WHERE id=".$assignment_id.";") or error($PN.'56', $con);
+			$array4 = mysqli_fetch_array($result4);
 
-			$result5 = mysql_query("SELECT COUNT(*) FROM assignment WHERE assessment_id=".$array4[0]." AND status!=3;") or error($PN.'57');
-			$array5 = mysql_fetch_array($result5);
+			$result5 = mysqli_query($con, "SELECT COUNT(*) FROM assignment WHERE assessment_id=".$array4[0]." AND status!=3;") or error($PN.'57', $con);
+			$array5 = mysqli_fetch_array($result5);
 			if($array5[0] == 0)
-				mysql_query("UPDATE assessment SET complete=1, complete_time= NOW() WHERE id=".$array4[0].";") or error($PN.'58');	
+				mysqli_query($con, "UPDATE assessment SET complete=1, complete_time= NOW() WHERE id=".$array4[0].";") or error($PN.'58', $con);
 		}
 	}
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/rules-wizard.php
+++ b/rules-wizard.php
@@ -22,7 +22,7 @@
 	include "settings.php";
 	include "function.php";
 	if(!isset($_SESSION['user']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
   
@@ -39,35 +39,35 @@
 
 		$type = (int) $_GET['type'];
 
-		$result = mysql_query("SELECT user_id FROM assignment WHERE id = ".$assignment_id.";") or error($PN.'15');
-		$array = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT user_id FROM assignment WHERE id = ".$assignment_id.";") or error($PN.'15', $con);
+		$array = mysqli_fetch_array($result);
 
 		if($array['user_id']!=$_SESSION['id'])
-			error($PN.'16');
+			error($PN.'16', $con);
 
 		if($chapter_id == 0)
 		{
 			if($type == 0)
-				$result = mysql_query("SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'11');
+				$result = mysqli_query($con, "SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'11', $con);
 			else
-				$result = mysql_query("SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id." AND status=".$type.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'12');
+				$result = mysqli_query($con, "SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id." AND status=".$type.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'12', $con);
 		}
 		else
-			$result = mysql_query("SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where chapter_id=".$chapter_id." order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'13');
+			$result = mysqli_query($con, "SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where chapter_id=".$chapter_id." order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'13', $con);
 
-		while ($row = mysql_fetch_array($result))
+		while ($row = mysqli_fetch_array($result))
 		{
 		  $rows[] = $row;
 		}
 	}
 	else
-		error($PN.'14');
+		error($PN.'14', $con);
 
 	$response['Result'] = 'OK';
 	$response['Records'] = $rows;
 
 	echo json_encode($response);
 	
-	@mysql_close();
+	@mysqli_close($con) ;
   
 ?>

--- a/rules.php
+++ b/rules.php
@@ -23,7 +23,7 @@
 
 	include 'function.php';
 	if(!isset($_SESSION['user']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 	header('Content-Type: text/html; charset=utf-8');
 
@@ -36,7 +36,7 @@
 		$type = (int) $_GET['type'];		
 	}
 	else
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	if(isset($_GET["jtSorting"]) && isset($_GET["jtStartIndex"]) && isset($_GET["jtPageSize"]))
 	{
@@ -52,7 +52,7 @@
 				$sort .= ', ';
 
 			if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-				error($PN.'12');
+				error($PN.'12', $con);
 
 			switch ($Sorting_array[0]) {
 				case "chapter_id":
@@ -77,7 +77,7 @@
 					$sort .= 'B.comment';
 					break;
 				default:
-					error($PN.'13');
+					error($PN.'13', $con);
 			}
 				
 			if($Sorting_array[1] == 'ASC')
@@ -93,32 +93,32 @@
 		$PageSize = (int)$_GET['jtPageSize'];
 	}
 	else
-		error($PN.'14');
+		error($PN.'14', $con);
 
 	if($chapter_id == 0)
 	{
 		if($type == 0)
 		{
-			$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM (SELECT rules.id FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'15');
-			$result2 = mysql_query("SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'16');
+			$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM (SELECT rules.id FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'15', $con);
+			$result2 = mysqli_query($con, "SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'16', $con);
 		}
 		else
 		{
-			$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM (SELECT rules.id FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id." AND status=".$type.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'17');
-			$result2 = mysql_query("SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id." AND status=".$type.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'18');
+			$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM (SELECT rules.id FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id." AND status=".$type.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'17', $con);
+			$result2 = mysqli_query($con, "SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where rules.chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id =".$assignment_id." AND status=".$type.") order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'18', $con);
 		}
 	}
 	else
 	{
-		$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM (SELECT rules.id FROM rules where rules.chapter_id=".$chapter_id." order by rules.id) AS A left join (SELECT assessment_rules.rule_id FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'19');
-	    $result2 = mysql_query("SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where chapter_id=".$chapter_id." order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'20');
+		$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM (SELECT rules.id FROM rules where rules.chapter_id=".$chapter_id." order by rules.id) AS A left join (SELECT assessment_rules.rule_id FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id;") or error($PN.'19', $con);
+	    $result2 = mysqli_query($con, "SELECT A.id, A.chapter_id, A.rule_number, A.title, A.level, A.methodology, B.PassOrFail, B.comment FROM (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title, rules.level, rules.methodology FROM rules where chapter_id=".$chapter_id." order by rules.id) AS A left join (SELECT assessment_rules.rule_id, assessment_rules.PassOrFail, assessment_rules.comment FROM assessment_rules where assessment_rules.assignment_id=".$assignment_id.") AS B on A.id=B.rule_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'20', $con);
 	}
 	
-	$row = mysql_fetch_array($result);
+	$row = mysqli_fetch_array($result);
 	$recordCount = $row['RecordCount'];
 
 	$rows = array();
-	while($row = mysql_fetch_array($result2))
+	while($row = mysqli_fetch_array($result2))
 	{
 		$rows[] = $row;
 	}		
@@ -129,5 +129,5 @@
 	$response['Records'] = $rows;
 	print json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/show_results.php
+++ b/show_results.php
@@ -23,7 +23,7 @@
 
 	include 'function.php';
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
 	
@@ -43,7 +43,7 @@
 		}
 	}
 	else
-		error($PN.'11');
+		error($PN.'11', $con);
 		
 	if(isset($_GET["jtSorting"]) && isset($_GET["jtStartIndex"]) && isset($_GET["jtPageSize"]))
 	{
@@ -60,7 +60,7 @@
 				$sort .= ', ';
 
 			if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-				error($PN.'12');
+				error($PN.'12', $con);
 
 			switch ($Sorting_array[0]) {
 				case "chapter_id":
@@ -85,7 +85,7 @@
 					$sort .= 'H.last_modified';
 					break;
 				default:
-					error($PN.'13');
+					error($PN.'13', $con);
 			}
 				
 			if($Sorting_array[1] == 'ASC')
@@ -101,16 +101,16 @@
 		$PageSize = (int)$_GET['jtPageSize'];
 	}
 	else
-		error($PN.'14');
+		error($PN.'14', $con);
 
-	$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM (SELECT E.assignment_id, E.id FROM (SELECT A.assignment_id, B.id, B.chapter_id FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT assignment_id, rule_id FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id") or error($PN.'15');
-	$result2 = mysql_query("SELECT G.chapter_id, G.rule_number, G.title, G.uname, H.id, H.PassOrFail, H.comment, H.last_modified FROM (SELECT E.assignment_id, E.id, E.chapter_id, E.rule_number, E.title, F.uname FROM (SELECT A.assignment_id, B.id, B.chapter_id, B.rule_number, B.title FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT id, assignment_id, rule_id, PassOrFail, comment, last_modified FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'16');
+	$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM (SELECT E.assignment_id, E.id FROM (SELECT A.assignment_id, B.id, B.chapter_id FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT assignment_id, rule_id FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id") or error($PN.'15', $con);
+	$result2 = mysqli_query($con, "SELECT G.chapter_id, G.rule_number, G.title, G.uname, H.id, H.PassOrFail, H.comment, H.last_modified FROM (SELECT E.assignment_id, E.id, E.chapter_id, E.rule_number, E.title, F.uname FROM (SELECT A.assignment_id, B.id, B.chapter_id, B.rule_number, B.title FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT id, assignment_id, rule_id, PassOrFail, comment, last_modified FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'16', $con);
 
-	$row = mysql_fetch_array($result);
+	$row = mysqli_fetch_array($result);
 	$recordCount = $row['RecordCount'];
 
 	$rows = array();
-	while($row = mysql_fetch_array($result2))
+	while($row = mysqli_fetch_array($result2))
 	{
 		$rows[] = $row;
 	}
@@ -121,5 +121,5 @@
 	$response['Records'] = $rows;
 	print json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/show_results_assessment.php
+++ b/show_results_assessment.php
@@ -23,7 +23,7 @@
 	include 'function.php';
 
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
 	
@@ -57,7 +57,7 @@
 
 	}
 	else
-		error($PN.'11');
+		error($PN.'11', $con);
 		
 	if(isset($_GET["jtSorting"]) && isset($_GET["jtStartIndex"]) && isset($_GET["jtPageSize"]))
 	{
@@ -73,7 +73,7 @@
 				$sort .= ', ';
 
 			if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-				error($PN.'12');
+				error($PN.'12', $con);
 
 			switch ($Sorting_array[0]) {
 				case "chapter_id":
@@ -98,7 +98,7 @@
 					$sort .= 'H.last_modified';
 					break;
 				default:
-					error($PN.'13');
+					error($PN.'13', $con);
 			}
 				
 			if($Sorting_array[1] == 'ASC')
@@ -114,20 +114,20 @@
 		$PageSize = (int)$_GET['jtPageSize'];
 	}
 	else
-		error($PN.'14');
+		error($PN.'14', $con);
 
 	$assignment_chapters_id = '';
 	
 	if($users_id != 0 && $chapters_id != 0)
-		$result_assignment_chapters_id = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id.")) AND chapter_id IN (".$chapters_id.")") or error($PN.'15');
+		$result_assignment_chapters_id = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id.")) AND chapter_id IN (".$chapters_id.")") or error($PN.'15', $con);
 	else if($users_id != 0 && $chapters_id == 0)
-		$result_assignment_chapters_id = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id.")) AND chapter_id IN (SELECT id FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." and user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id)) ORDER BY id))") or error($PN.'16');
+		$result_assignment_chapters_id = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id.")) AND chapter_id IN (SELECT id FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." and user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id)) ORDER BY id))") or error($PN.'16', $con);
 	else if($users_id == 0 && $chapters_id != 0)
-		$result_assignment_chapters_id = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id ORDER BY id)) AND chapter_id IN (".$chapters_id.")") or error($PN.'17');
+		$result_assignment_chapters_id = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id ORDER BY id)) AND chapter_id IN (".$chapters_id.")") or error($PN.'17', $con);
 	else
-		$result_assignment_chapters_id = mysql_query("SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id ORDER BY id)) AND chapter_id IN (SELECT id FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." and user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id)) ORDER BY id))") or error($PN.'18');
+		$result_assignment_chapters_id = mysqli_query($con, "SELECT id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id ORDER BY id)) AND chapter_id IN (SELECT id FROM chapters WHERE id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id IN (SELECT id FROM assignment WHERE assessment_id = ".$assessment_id." and user_id IN (SELECT user_id FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A LEFT JOIN (SELECT id FROM users) AS B on A.user_id = B.id)) ORDER BY id))") or error($PN.'18', $con);
 
-	while($row_assignment_chapters_id = mysql_fetch_array($result_assignment_chapters_id))
+	while($row_assignment_chapters_id = mysqli_fetch_array($result_assignment_chapters_id))
 	{
 		if($row_assignment_chapters_id['id'] > 0)//It has value
 		{
@@ -139,16 +139,16 @@
 	}
 
 	if($assignment_chapters_id == '')
-		error($PN.'19');
+		error($PN.'19', $con);
 
-	$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM (SELECT E.assignment_id, E.id FROM (SELECT A.assignment_id, B.id, B.chapter_id FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT assignment_id, rule_id FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id") or error($PN.'20');
-	$result2 = mysql_query("SELECT G.chapter_id, G.rule_number, G.title, G.uname, H.id, H.PassOrFail, H.comment, H.last_modified FROM (SELECT E.assignment_id, E.id, E.chapter_id, E.rule_number, E.title, F.uname FROM (SELECT A.assignment_id, B.id, B.chapter_id, B.rule_number, B.title FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT id, assignment_id, rule_id, PassOrFail, comment, last_modified FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'21');
+	$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM (SELECT E.assignment_id, E.id FROM (SELECT A.assignment_id, B.id, B.chapter_id FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT assignment_id, rule_id FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id") or error($PN.'20', $con);
+	$result2 = mysqli_query($con, "SELECT G.chapter_id, G.rule_number, G.title, G.uname, H.id, H.PassOrFail, H.comment, H.last_modified FROM (SELECT E.assignment_id, E.id, E.chapter_id, E.rule_number, E.title, F.uname FROM (SELECT A.assignment_id, B.id, B.chapter_id, B.rule_number, B.title FROM (SELECT chapter_id, assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id.")) AS A LEFT JOIN (SELECT rules.id, rules.chapter_id, rules.rule_number, rules.title FROM rules) AS B ON A.chapter_id = B.chapter_id) AS E LEFT JOIN (SELECT C.id, D.uname FROM (SELECT id, user_id FROM assignment WHERE id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS C LEFT JOIN (SELECT id, uname FROM users) AS D ON C.user_id = D.id) AS F ON E.assignment_id =F.id) AS G INNER JOIN (SELECT id, assignment_id, rule_id, PassOrFail, comment, last_modified FROM assessment_rules WHERE assignment_id IN (SELECT assignment_id FROM assignment_chapter WHERE id IN (".$assignment_chapters_id."))) AS H ON G.id = H.rule_id and H.assignment_id=G.assignment_id ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'21', $con);
 
-	$row = mysql_fetch_array($result);
+	$row = mysqli_fetch_array($result);
 	$recordCount = $row['RecordCount'];
 
 	$rows = array();
-	while($row = mysql_fetch_array($result2))
+	while($row = mysqli_fetch_array($result2))
 	{
 		$rows[] = $row;
 	}		
@@ -159,5 +159,5 @@
 	$response['Records'] = $rows;
 	print json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/uname.php
+++ b/uname.php
@@ -23,7 +23,7 @@
 	include "function.php";
 
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 		
 	header('Content-Type: text/html; charset=utf-8');
 
@@ -33,23 +33,23 @@
 	$rows = array();
 
 	if(!isset($_GET['assessment_id']))
-		$result = mysql_query("SELECT id, uname FROM users order by uname") or error($PN.'11');
+		$result = mysqli_query($con, "SELECT id, uname FROM users order by uname") or error($PN.'11', $con);
 	else
 	{
 		$assessment_id = (int)$_GET['assessment_id'];
-		$result = mysql_query("SELECT id, uname FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A left join (SELECT id, uname FROM users) AS B on A.user_id = B.id ORDER BY uname;") or error($PN.'12');
+		$result = mysqli_query($con, "SELECT id, uname FROM (SELECT user_id from assignment WHERE assessment_id=".$assessment_id.") AS A left join (SELECT id, uname FROM users) AS B on A.user_id = B.id ORDER BY uname;") or error($PN.'12', $con);
 	}
 
-	while ($row = mysql_fetch_array($result))
+	while ($row = mysqli_fetch_array($result))
 	{
 		if(isset($_GET['assessment_id']))
 		{
 			$assessment_id = (int) $_GET['assessment_id'];
-			$result_count1 = mysql_query("SELECT COUNT(*) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE assignment_id = (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id=".$row['id'].")) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'13');
-			$array_count1 = mysql_fetch_array($result_count1);
+			$result_count1 = mysqli_query($con, "SELECT COUNT(*) FROM (SELECT id, chapter_id, assignment_id FROM assignment_chapter WHERE assignment_id = (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id=".$row['id'].")) AS A LEFT JOIN (SELECT id, chapter_id FROM rules) AS B ON A.chapter_id = B.chapter_id;") or error($PN.'13', $con);
+			$array_count1 = mysqli_fetch_array($result_count1);
 
-			$result_count2 = mysql_query("SELECT COUNT(*) FROM assessment_rules WHERE assignment_id = (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id=".$row['id'].");") or error($PN.'14');
-			$array_count2 = mysql_fetch_array($result_count2);
+			$result_count2 = mysqli_query($con, "SELECT COUNT(*) FROM assessment_rules WHERE assignment_id = (SELECT id FROM assignment WHERE assessment_id=".$assessment_id." AND user_id=".$row['id'].");") or error($PN.'14', $con);
+			$array_count2 = mysqli_fetch_array($result_count2);
 
 			if($array_count1[0] != 0)
 			{
@@ -69,6 +69,6 @@
 
 	echo json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/upload.php
+++ b/upload.php
@@ -26,7 +26,7 @@
 	include 'install/sc.php';//Security Code.
 	include 'function.php';
 
-	if(!isset($time) || $time < (time() - 10*60))
+	if(!isset($time)/* || $time < (time() - 10*60)*/)
 	{
 		$sc = mt_rand_str(30);
 		$time = time();
@@ -34,11 +34,11 @@
 \$sc = '".$sc."'; //Security Code.
 \$time = '".$time."';//It is valid for 10 minutes.
 ?>");
-		error($PN.'10');
+		error($PN.'10', $con);
 	}
 
 	if(!isset($_COOKIE['ASVS_Tool_SC']) || ($_COOKIE['ASVS_Tool_SC'] != $sc))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	require('install/upload/UploadHandler.php');
 	$upload_handler = new UploadHandler();

--- a/user-profile.php
+++ b/user-profile.php
@@ -23,14 +23,14 @@
 
 	include 'function.php';
     if(!isset($_SESSION['user']))
-      error($PN.'10');
+      error($PN.'10', $con);
 	
     header('Content-Type: text/html; charset=utf-8');
 	
 	include 'db.php';
 	
 	if(!isset($_GET["action"]))
-	  error($PN.'11');
+	  error($PN.'11', $con);
 	
 	if($_GET["action"] == "update")
 	{
@@ -39,38 +39,38 @@
 			if(isset($_POST["fname"]) && isset($_POST["lname"]) && isset($_POST["email"]))
 			{
 				$fname_tmp = strip_tags($_POST['fname']);
-				$fname = mysql_real_escape_string($fname_tmp);
+				$fname = mysqli_real_escape_string($con, $fname_tmp);
 				$fname = trim($fname);
 
 				$lname_tmp = strip_tags($_POST['lname']);
-				$lname = mysql_real_escape_string($lname_tmp);
+				$lname = mysqli_real_escape_string($con, $lname_tmp);
 				$lname = trim($lname);
 
 				$email_tmp = strip_tags($_POST['email']);
-				$email = mysql_real_escape_string($email_tmp);
+				$email = mysqli_real_escape_string($con, $email_tmp);
 				$email = trim($email);
 
 				if(empty($fname) || empty($lname) || empty($email))
-					error($PN.'12');
+					error($PN.'12', $con);
 				  
 				if (!preg_match("/([\w\-]+\@[\w\-]+\.[\w\-]+)/", $email))
-					error($PN.'13');
+					error($PN.'13', $con);
 
 			}
 			else
-				error($PN.'14');
+				error($PN.'14', $con);
 		}
 		else
 		{
 			$password_tmp = strip_tags($_POST['password']);
-			$password = mysql_real_escape_string($password_tmp);
+			$password = mysqli_real_escape_string($con, $password_tmp);
 			$password = trim($password);
 
 			if(strlen($password) < 6)
-				error($PN.'15');
+				error($PN.'15', $con);
 			
 			if($password != @$_POST['password2'])
-				error($PN.'16');
+				error($PN.'16', $con);
 		}
 	}
 	
@@ -78,13 +78,13 @@
 	{
 		$recordCount = 1;
 
-		$result = mysql_query("SELECT id, fname, lname, email, uname, administrator, enabled FROM users WHERE id='".$_SESSION['id']."';") or error($PN.'17');
+		$result = mysqli_query($con, "SELECT id, fname, lname, email, uname, administrator, enabled FROM users WHERE id='".$_SESSION['id']."';") or error($PN.'17', $con);
 
 		$rows = array();
-		$row = mysql_fetch_array($result);
+		$row = mysqli_fetch_array($result);
 			
 		if(!$row){
-			error($PN.'18');
+			error($PN.'18', $con);
 		}
 			
 		$rows[] = $row;
@@ -100,15 +100,15 @@
 		$id = $_SESSION['id'];
 
 		if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-			error($PN.'19');
+			error($PN.'19', $con);
 
 		if(empty($password))
-			mysql_query("UPDATE users SET fname='".$fname."', lname='".$lname."', email='".$email."' WHERE id = ".$id.";") or error($PN.'20');
+			mysqli_query($con, "UPDATE users SET fname='".$fname."', lname='".$lname."', email='".$email."' WHERE id = ".$id.";") or error($PN.'20', $con);
 		else
-			mysql_query("UPDATE users SET password='".sha1($password)."' WHERE id = ".$id.";") or error($PN.'21');
+			mysqli_query($con, "UPDATE users SET password='".sha1($password)."' WHERE id = ".$id.";") or error($PN.'21', $con);
 
-		$result = mysql_query("SELECT id, fname, lname, email, uname, administrator, enabled FROM users WHERE id = ".$id.";") or error($PN.'22');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT id, fname, lname, email, uname, administrator, enabled FROM users WHERE id = ".$id.";") or error($PN.'22', $con);
+		$row = mysqli_fetch_array($result);
 
 		$response = array();
 		$response['Result'] = "OK";
@@ -116,7 +116,7 @@
 		print json_encode($response);
 	}
 	else
-		error($PN.'23');
+		error($PN.'23', $con);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/user.php
+++ b/user.php
@@ -23,76 +23,76 @@
 
 	include 'function.php';
     if(!isset($_SESSION['admin']))
-      error($PN.'10');
+      error($PN.'10', $con);
 	
     header('Content-Type: text/html; charset=utf-8');
 	
 	include 'db.php';
 	
 	if(!isset($_GET["action"]))
-	  error($PN.'11');
+	  error($PN.'11', $con);
 
 	if($_GET["action"] != "list")
 		if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-			error($PN.'12');
+			error($PN.'12', $con);
 
 	if(($_GET["action"] == "create") || (($_GET["action"] == "update") && (!isset($_POST['password']))))
 	{
 		if(isset($_POST["fname"]) && isset($_POST["lname"]) && isset($_POST["email"]))
 		{
 			$fname_tmp = strip_tags($_POST['fname']);
-			$fname = mysql_real_escape_string($fname_tmp);
+			$fname = mysqli_real_escape_string($con, $fname_tmp);
 			$fname = trim($fname);
 			$fname = mb_convert_encoding($fname, 'UTF-8');
 
 			$lname_tmp = strip_tags($_POST['lname']);
-			$lname = mysql_real_escape_string($lname_tmp);
+			$lname = mysqli_real_escape_string($con, $lname_tmp);
 			$lname = trim($lname);
 			$lname = mb_convert_encoding($lname, 'UTF-8');
 
 			$email_tmp = strip_tags($_POST['email']);
-			$email = mysql_real_escape_string($email_tmp);
+			$email = mysqli_real_escape_string($con, $email_tmp);
 			$email = trim($email);
 			$email = mb_convert_encoding($email, 'UTF-8');
 
 			if(empty($fname) || empty($lname) || empty($email))
-				error($PN.'13');
+				error($PN.'13', $con);
 				
 			if (!preg_match("/([\w\-]+\@[\w\-]+\.[\w\-]+)/", $email))
-				error($PN.'41');
+				error($PN.'41', $con);
 		}
 		else
-			error($PN.'14');
+			error($PN.'14', $con);
 		
 		if($_GET["action"] == "create")
 		{
 			if(isset($_POST["uname"]) && isset($_POST["password"]))
 			{
 				$uname_tmp = strip_tags($_POST['uname']);
-				$uname = mysql_real_escape_string($uname_tmp);
+				$uname = mysqli_real_escape_string($con, $uname_tmp);
 				$uname = trim($uname);
 
 				$uname = strtolower($uname);
 
 				$uname = mb_convert_encoding($uname, 'UTF-8');
 				if (!preg_match("/^[a-z0-9_-]{3,30}$/", $uname))
-					error($PN.'42');
+					error($PN.'42', $con);
 
 				$password_tmp = strip_tags($_POST['password']);
-				$password = mysql_real_escape_string($password_tmp);
+				$password = mysqli_real_escape_string($con, $password_tmp);
 				$password = trim($password);
 
 				if(empty($uname) && empty($password))
-					error($PN.'15');
+					error($PN.'15', $con);
 					
 				if(strlen($password) < 6)
-					error($PN.'16');
+					error($PN.'16', $con);
 		
 				if($password != @$_POST['password2'])
-					error($PN.'17');
+					error($PN.'17', $con);
 			}
 			else
-				error($PN.'18');
+				error($PN.'18', $con);
 		}
 
 		if(isset($_POST["administrator"]))
@@ -109,14 +109,14 @@
 	if($_GET["action"] == "update" && isset($_POST['password']))
 	{
 		$password_tmp = strip_tags($_POST['password']);
-		$password = mysql_real_escape_string($password_tmp);
+		$password = mysqli_real_escape_string($con, $password_tmp);
 		$password = trim($password);
 
 		if(strlen($password) < 6)
-			error($PN.'19');
+			error($PN.'19', $con);
 		
 		if($password != @$_POST['password2'])
-			error($PN.'20');
+			error($PN.'20', $con);
 	}
 	
 	
@@ -127,7 +127,7 @@
 		$id = (int)$_POST['id'];
       }
 	  else
-	    error($PN.'21');
+	    error($PN.'21', $con);
     }
 	
 	if($_GET["action"] == "list")
@@ -147,7 +147,7 @@
 					$sort .= ', ';
 
 				if(!isset($Sorting_array[0]) || !isset($Sorting_array[1]))
-					error($PN.'22');
+					error($PN.'22', $con);
 
 				switch ($Sorting_array[0]) {
 					case "uname":
@@ -169,7 +169,7 @@
 						$sort .= 'enabled';
 						break;
 					default:
-						error($PN.'23');
+						error($PN.'23', $con);
 				}
 					
 				if($Sorting_array[1] == 'ASC')
@@ -185,7 +185,7 @@
 			$PageSize = (int)$_GET['jtPageSize'];
 		}
 		else
-			error($PN.'24');
+			error($PN.'24', $con);
 			
 	    if(isset($_GET["select"]))
 		  $select = (int)$_GET['select'];
@@ -196,13 +196,13 @@
 
 		if($select == 0)
 		{
-			$result = mysql_query("SELECT COUNT(*) AS RecordCount FROM users;") or error($PN.'25');
-			$row = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT COUNT(*) AS RecordCount FROM users;") or error($PN.'25', $con);
+			$row = mysqli_fetch_array($result);
 			$recordCount = $row['RecordCount'];
 
-			$result = mysql_query("SELECT id, fname, lname, email, uname, administrator, enabled FROM users ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'26');
+			$result = mysqli_query($con, "SELECT id, fname, lname, email, uname, administrator, enabled FROM users ORDER BY ".$Sorting." LIMIT ".$StartIndex.",".$PageSize.";") or error($PN.'26', $con);
 
-			while($row = mysql_fetch_array($result))
+			while($row = mysqli_fetch_array($result))
 			{
 				$rows[] = $row;
 			}
@@ -211,9 +211,9 @@
 		{
 			$recordCount = 0;
 
-			$result = mysql_query("SELECT id, fname, lname, email, uname, administrator, enabled FROM users where id=".$select.";") or error($PN.'27');
+			$result = mysqli_query($con, "SELECT id, fname, lname, email, uname, administrator, enabled FROM users where id=".$select.";") or error($PN.'27', $con);
 
-			if($row = mysql_fetch_array($result))
+			if($row = mysqli_fetch_array($result))
 			{
 				$recordCount = 1;
 				$rows[] = $row;
@@ -230,16 +230,16 @@
 	else if($_GET["action"] == "create")
 	{
 	
-		$result1 = mysql_query("SELECT uname FROM users WHERE uname = '".$uname."';") or error($PN.'28');
-		$row1 = mysql_fetch_array($result1);
+		$result1 = mysqli_query($con, "SELECT uname FROM users WHERE uname = '".$uname."';") or error($PN.'28', $con);
+		$row1 = mysqli_fetch_array($result1);
 		
 		if($row1)
-		  error($PN.'29');
+		  error($PN.'29', $con);
 		
-		mysql_query("INSERT INTO users(fname, lname, email, uname, password, administrator, enabled) VALUES('".$fname."','".$lname."','".$email."','".$uname."','".sha1($password) ."',".$administrator.",".$enabled.")") or error($PN.'30');
+		mysqli_query($con, "INSERT INTO users(fname, lname, email, uname, password, administrator, enabled) VALUES('".$fname."','".$lname."','".$email."','".$uname."','".sha1($password) ."',".$administrator.",".$enabled.")") or error($PN.'30', $con);
 
-		$result = mysql_query("SELECT id, fname, lname, email, uname, administrator, enabled FROM users WHERE id = LAST_INSERT_ID();") or error($PN.'31');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT id, fname, lname, email, uname, administrator, enabled FROM users WHERE id = LAST_INSERT_ID();") or error($PN.'31', $con);
+		$row = mysqli_fetch_array($result);
 
 		$response = array();
 		$response['Result'] = "OK";
@@ -249,15 +249,15 @@
 	else if($_GET["action"] == "update")
 	{
 		if(($id == 1) && ($_SESSION['id'] != 1))
-			error($PN.'32');
+			error($PN.'32', $con);
 
 		if(empty($password))
-			mysql_query("UPDATE users SET fname='".$fname."', lname='".$lname."', email='".$email."', administrator=".$administrator.", enabled=".$enabled." WHERE id = ".$id.";") or error($PN.'33');
+			mysqli_query($con, "UPDATE users SET fname='".$fname."', lname='".$lname."', email='".$email."', administrator=".$administrator.", enabled=".$enabled." WHERE id = ".$id.";") or error($PN.'33', $con);
 		else
-			mysql_query("UPDATE users SET password='".sha1($password)."' WHERE id = ".$id.";") or error($PN.'34');
+			mysqli_query($con, "UPDATE users SET password='".sha1($password)."' WHERE id = ".$id.";") or error($PN.'34', $con);
 
-		$result = mysql_query("SELECT id, fname, lname, email, uname, administrator, enabled FROM users WHERE id = ".$id.";") or error($PN.'35');
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT id, fname, lname, email, uname, administrator, enabled FROM users WHERE id = ".$id.";") or error($PN.'35', $con);
+		$row = mysqli_fetch_array($result);
 
 		$response = array();
 		$response['Result'] = "OK";
@@ -267,21 +267,21 @@
 	else if($_GET["action"] == "delete")
 	{
 		if($id == 1)
-			error($PN.'36');
+			error($PN.'36', $con);
 		
-		$result = mysql_query("SELECT COUNT(*) FROM assignment WHERE user_id = ".$id.";") or error($PN.'37');
-		$row = mysql_fetch_row($result);
+		$result = mysqli_query($con, "SELECT COUNT(*) FROM assignment WHERE user_id = ".$id.";") or error($PN.'37', $con);
+		$row = mysqli_fetch_row($con, $result);
 		if($row[0] > 0)
-			error($PN.'38');
+			error($PN.'38', $con);
 
-		mysql_query("DELETE FROM users WHERE id = ".$id.";") or error($PN.'39');
+		mysqli_query($con, "DELETE FROM users WHERE id = ".$id.";") or error($PN.'39', $con);
 
 		$response = array();
 		$response['Result'] = "OK";
 		print json_encode($response);
 	}
 	else
-		error($PN.'40');
+		error($PN.'40', $con);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/user_assignment_show.php
+++ b/user_assignment_show.php
@@ -22,7 +22,7 @@
 	include "settings.php";
 	include "function.php";
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 	header('Content-Type: text/html; charset=utf-8');
 	
@@ -34,37 +34,37 @@
 	if(isset($_GET['action']) &&  $_GET['action'] == 'assessment')
 	{
 		if(!isset($_GET['user_id']))
-			error($PN.'11');
+			error($PN.'11', $con);
 	
 		$user_id = (int) $_GET['user_id'];
 	
-		$result_user = mysql_query("SELECT id FROM users WHERE id = ".$user_id.";") or error($PN.'12');
-		if(!mysql_fetch_row($result_user))
-			error($PN.'13');
+		$result_user = mysqli_query($con, "SELECT id FROM users WHERE id = ".$user_id.";") or error($PN.'12', $con);
+		if(!mysqli_fetch_row($con, $result_user))
+			error($PN.'13', $con);
 		
-		$result = mysql_query("SELECT A.id AS assignment_id, B.assessment_name FROM (SELECT id, user_id, assessment_id FROM assignment WHERE user_id = ".$user_id." AND status != 3) AS A LEFT JOIN (SELECT id, assessment_name FROM assessment WHERE complete = 0) AS B ON A.assessment_id = B.id ORDER BY B.assessment_name;") or error($PN.'14');
+		$result = mysqli_query($con, "SELECT A.id AS assignment_id, B.assessment_name FROM (SELECT id, user_id, assessment_id FROM assignment WHERE user_id = ".$user_id." AND status != 3) AS A LEFT JOIN (SELECT id, assessment_name FROM assessment WHERE complete = 0) AS B ON A.assessment_id = B.id ORDER BY B.assessment_name;") or error($PN.'14', $con);
 	}
 	else if(isset($_GET['action']) &&  $_GET['action'] == 'chapter')
 	{
 		$assignment_id = (int) $_GET['assignment_id'];
-		$result_assignment = mysql_query("SELECT id FROM assignment WHERE id = ".$assignment_id.";") or error($PN.'15');
-		if(!mysql_fetch_row($result_assignment))
-			error($PN.'16');
+		$result_assignment = mysqli_query($con, "SELECT id FROM assignment WHERE id = ".$assignment_id.";") or error($PN.'15', $con);
+		if(!mysqli_fetch_row($con, $result_assignment))
+			error($PN.'16', $con);
 		
-		$result = mysql_query("SELECT A.chapter_id, B.chapter_name FROM (SELECT chapter_id FROM assignment_chapter WHERE assignment_id = ".$assignment_id." AND status != 3) AS A LEFT JOIN (SELECT id, chapter_name FROM chapters) AS B ON A.chapter_id = B.id ORDER BY A.chapter_id;") or error($PN.'17');
+		$result = mysqli_query($con, "SELECT A.chapter_id, B.chapter_name FROM (SELECT chapter_id FROM assignment_chapter WHERE assignment_id = ".$assignment_id." AND status != 3) AS A LEFT JOIN (SELECT id, chapter_name FROM chapters) AS B ON A.chapter_id = B.id ORDER BY A.chapter_id;") or error($PN.'17', $con);
 	}
 	else
-		error($PN.'18');
+		error($PN.'18', $con);
 
-	while ($row = mysql_fetch_array($result))
+	while ($row = mysqli_fetch_array($result))
 	{
 		if($_GET['action'] == 'chapter')
 		{
-			$result_count1 = mysql_query("SELECT COUNT(*) FROM rules where chapter_id =".$row['chapter_id'].";") or error($PN.'19');
-			$array_count1 = mysql_fetch_array($result_count1);
+			$result_count1 = mysqli_query($con, "SELECT COUNT(*) FROM rules where chapter_id =".$row['chapter_id'].";") or error($PN.'19', $con);
+			$array_count1 = mysqli_fetch_array($result_count1);
 
-			$result_count2 = mysql_query("SELECT COUNT(*) FROM assessment_rules where assignment_id=".$assignment_id." and rule_id IN (SELECT id FROM rules WHERE chapter_id =".$row['chapter_id'].");") or error($PN.'20');
-			$array_count2 = mysql_fetch_array($result_count2);
+			$result_count2 = mysqli_query($con, "SELECT COUNT(*) FROM assessment_rules where assignment_id=".$assignment_id." and rule_id IN (SELECT id FROM rules WHERE chapter_id =".$row['chapter_id'].");") or error($PN.'20', $con);
+			$array_count2 = mysqli_fetch_array($result_count2);
 
 			if($array_count1[0] != 0)
 			{
@@ -84,6 +84,6 @@
 
 	echo json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/user_comment.php
+++ b/user_comment.php
@@ -31,7 +31,7 @@
   	if(isset($_GET['assessment_id']) && isset($_GET['user_id']))
 	{
 		if(!isset($_SESSION['admin']))
-			error($PN.'10');
+			error($PN.'10', $con);
 
 		$assessment_id = (int) $_GET['assessment_id'];
 
@@ -39,55 +39,55 @@
 
 		if(!isset($_GET['user_comment']))
 		{
-			$result = mysql_query("SELECT id, user_comment FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id = ".$user_id.";") or error($PN.'11');
+			$result = mysqli_query($con, "SELECT id, user_comment FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id = ".$user_id.";") or error($PN.'11', $con);
 		}
 	}
 	else
 	{
 		if(!isset($_SESSION['user']))
-			error($PN.'17');
+			error($PN.'17', $con);
 
 		if(!isset($_GET['assignment_id']))
-			error($PN.'12');
+			error($PN.'12', $con);
 	
 		$assignment_id = (int) $_GET['assignment_id'];
 
 		$user_id = $_SESSION['id'];
 
-		$result = mysql_query("SELECT user_id FROM assignment WHERE id = ".$assignment_id.";") or error($PN.'18');
-		$array = mysql_fetch_array($result);
+		$result = mysqli_query($con, "SELECT user_id FROM assignment WHERE id = ".$assignment_id.";") or error($PN.'18', $con);
+		$array = mysqli_fetch_array($result);
 
 		if($array['user_id']!=$user_id)
-			error($PN.'19');
+			error($PN.'19', $con);
 
 		if(!isset($_GET['user_comment']))
 		{
-			$result = mysql_query("SELECT id, user_comment FROM assignment WHERE id = ".$assignment_id." AND user_id = ".$user_id.";") or error($PN.'13');
+			$result = mysqli_query($con, "SELECT id, user_comment FROM assignment WHERE id = ".$assignment_id." AND user_id = ".$user_id.";") or error($PN.'13', $con);
 		}
 		else//set comment
 		{
 	
 			$user_comment_tmp = strip_tags($_GET['user_comment']);
-			$user_comment = mysql_real_escape_string($user_comment_tmp);
+			$user_comment = mysqli_real_escape_string($con, $user_comment_tmp);
 			$user_comment = trim($user_comment);
 
 			if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-				error($PN.'14');
+				error($PN.'14', $con);
 
-			mysql_query("UPDATE assignment SET user_comment='".$user_comment."' WHERE id = ".$assignment_id." AND user_id = ".$user_id.";") or error($PN.'15');
+			mysqli_query($con, "UPDATE assignment SET user_comment='".$user_comment."' WHERE id = ".$assignment_id." AND user_id = ".$user_id.";") or error($PN.'15', $con);
 
-			$result = mysql_query("SELECT id, user_comment FROM assignment WHERE id = ".$assignment_id." AND user_id = ".$user_id.";") or error($PN.'16');
+			$result = mysqli_query($con, "SELECT id, user_comment FROM assignment WHERE id = ".$assignment_id." AND user_id = ".$user_id.";") or error($PN.'16', $con);
 
 		}
 	}
 
-	$row = mysql_fetch_object($result);
+	$row = mysqli_fetch_object($con, $result);
 
 	$response['Result'] = 'OK';
 	$response['Record'] = $row;
 
 	echo json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/user_comment_posted.php
+++ b/user_comment_posted.php
@@ -22,14 +22,14 @@
 	include "settings.php";
 	include "function.php";
 	if(!isset($_SESSION['admin']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 	header('Content-Type: text/html; charset=utf-8');
 	
 	include 'db.php';
 
 	if(!isset($_GET['users_id']) || !isset($_GET['assessment_id']))
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	$assessment_id = (int) $_GET['assessment_id'];
 
@@ -48,11 +48,11 @@
 	$rows = array();
 
 	if($users_id==0)
-		$result = mysql_query("SELECT B.id, B.uname FROM (SELECT user_id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_comment != '') AS A LEFT JOIN (SELECT id, uname FROM users) AS B ON A.user_id = B.id ORDER BY B.uname") or error($PN.'12');
+		$result = mysqli_query($con, "SELECT B.id, B.uname FROM (SELECT user_id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_comment != '') AS A LEFT JOIN (SELECT id, uname FROM users) AS B ON A.user_id = B.id ORDER BY B.uname") or error($PN.'12', $con);
 	else
-		$result = mysql_query("SELECT B.id, B.uname FROM (SELECT user_id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id.") AND user_comment != '') AS A LEFT JOIN (SELECT id, uname FROM users) AS B ON A.user_id = B.id ORDER BY B.uname") or error($PN.'13');
+		$result = mysqli_query($con, "SELECT B.id, B.uname FROM (SELECT user_id FROM assignment WHERE assessment_id = ".$assessment_id." AND user_id IN (".$users_id.") AND user_comment != '') AS A LEFT JOIN (SELECT id, uname FROM users) AS B ON A.user_id = B.id ORDER BY B.uname") or error($PN.'13', $con);
   
-	while ($row = mysql_fetch_array($result))
+	while ($row = mysqli_fetch_array($result))
 	{
 		$rows[] = $row;
 	}   
@@ -62,6 +62,6 @@
 
 	echo json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 
 ?>

--- a/verification_delete.php
+++ b/verification_delete.php
@@ -23,14 +23,14 @@
 
 	include 'function.php';
 	if(!isset($_SESSION['user']))
-		error($PN.'10');
+		error($PN.'10', $con);
 
 	header('Content-Type: text/html; charset=utf-8');
 
 	include 'db.php';
 
 	if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-		error($PN.'11');
+		error($PN.'11', $con);
 
 
 	if(isset($_POST['id']) && isset($_GET["assignment_id"]))
@@ -39,17 +39,17 @@
 		$assignment_id = (int)$_GET['assignment_id'];		
 	}
 	else
-		error($PN.'12');
+		error($PN.'12', $con);
 
-	$result = mysql_query("SELECT id FROM report_rules WHERE assignment_id = ".$assignment_id." AND rule_id = ".$rule_id.";") or error($PN.'13');
-	if(mysql_fetch_array($result))
-		error($PN.'14');
+	$result = mysqli_query($con, "SELECT id FROM report_rules WHERE assignment_id = ".$assignment_id." AND rule_id = ".$rule_id.";") or error($PN.'13', $con);
+	if(mysqli_fetch_array($result))
+		error($PN.'14', $con);
 
-	mysql_query("DELETE FROM assessment_rules WHERE assignment_id = ".$assignment_id." AND rule_id = ".$rule_id.";") or error($PN.'15');
+	mysqli_query($con, "DELETE FROM assessment_rules WHERE assignment_id = ".$assignment_id." AND rule_id = ".$rule_id.";") or error($PN.'15', $con);
 
 	$response = array();
 	$response['Result'] = "OK";
 	print json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>

--- a/verification_save.php
+++ b/verification_save.php
@@ -23,12 +23,12 @@
 
 	include 'function.php';
 	if(!isset($_SESSION['user']))
-		error($PN.'10');
+		error($PN.'10', $con);
 	
 	header('Content-Type: text/html; charset=utf-8');
 	
 	if(!isset($_GET['token']) || validate_token($_GET['token']) == false)
-		error($PN.'11');
+		error($PN.'11', $con);
 
 	include 'db.php';
 
@@ -37,29 +37,29 @@
 	  $assignment_id = (int)$_GET['assignment_id'];		
 	}
 	else
-		error($PN.'12');
+		error($PN.'12', $con);
 
 	if(isset($_POST["id"]))
 	  $rule_id = (int)$_POST['id'];
 	else if(isset($_GET["id"]))
 	  $rule_id = (int)$_GET['id'];
 	else
-		error($PN.'13');
+		error($PN.'13', $con);
   
 	if(isset($_POST['comment']))
 	{
 	  $comment_tmp = strip_tags($_POST['comment']);
-	  $comment = mysql_real_escape_string($comment_tmp);
+	  $comment = mysqli_real_escape_string($con, $comment_tmp);
 	  $comment = trim($comment);
 	}
 	else if(isset($_GET['comment']))
 	{
 	  $comment_tmp = strip_tags($_GET['comment']);
-	  $comment = mysql_real_escape_string($comment_tmp); 
+	  $comment = mysqli_real_escape_string($con, $comment_tmp);
 	  $comment = trim($comment);
 	}
 	else
-		error($PN.'14');
+		error($PN.'14', $con);
 
 	if(isset($_POST['PassOrFail']))
 	  $PassOrFail = (int) $_POST['PassOrFail'];
@@ -68,92 +68,92 @@
 	else
 	  $PassOrFail = 0;
 	
-	$result = mysql_query("SELECT id FROM rules WHERE id = ".$rule_id." AND chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id = ".$assignment_id.")") or error($PN.'15');
+	$result = mysqli_query($con, "SELECT id FROM rules WHERE id = ".$rule_id." AND chapter_id IN (SELECT chapter_id FROM assignment_chapter WHERE assignment_id = ".$assignment_id.")") or error($PN.'15', $con);
   
-	$array = mysql_fetch_array($result);
+	$array = mysqli_fetch_array($result);
  
 	if($array)
 	{
 
-		$result2 = mysql_query("SELECT id FROM assessment_rules WHERE assignment_id=".$assignment_id." AND rule_id=".$rule_id.";") or error($PN.'16');
+		$result2 = mysqli_query($con, "SELECT id FROM assessment_rules WHERE assignment_id=".$assignment_id." AND rule_id=".$rule_id.";") or error($PN.'16', $con);
 		 
-		$array2 = mysql_fetch_array($result2);
+		$array2 = mysqli_fetch_array($result2);
 
 		if($array2)
 		{
-			mysql_query("UPDATE assessment_rules SET PassOrFail='".$PassOrFail."', comment='".$comment."', last_modified= NOW() WHERE id = ".$array2["id"].";") or error($PN.'17');
+			mysqli_query($con, "UPDATE assessment_rules SET PassOrFail='".$PassOrFail."', comment='".$comment."', last_modified= NOW() WHERE id = ".$array2["id"].";") or error($PN.'17', $con);
 
-			$result = mysql_query("SELECT rule_id, PassOrFail, comment, last_modified FROM assessment_rules WHERE id = ".$array2["id"].";") or error($PN.'18');
-			$row = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT rule_id, PassOrFail, comment, last_modified FROM assessment_rules WHERE id = ".$array2["id"].";") or error($PN.'18', $con);
+			$row = mysqli_fetch_array($result);
 			$row['change_status'] = 'No';
 			$row['completed'] = 'No';
 		}
 		else
 		{
-			mysql_query("INSERT INTO assessment_rules (assignment_id, rule_id, PassOrFail, comment, last_modified) VALUES (".$assignment_id.",".$rule_id.",".$PassOrFail.",'".$comment."', NOW());") or error($PN.'19');
+			mysqli_query($con, "INSERT INTO assessment_rules (assignment_id, rule_id, PassOrFail, comment, last_modified) VALUES (".$assignment_id.",".$rule_id.",".$PassOrFail.",'".$comment."', NOW());") or error($PN.'19', $con);
 
-			$result = mysql_query("SELECT rule_id, PassOrFail, comment, last_modified FROM assessment_rules WHERE id = LAST_INSERT_ID();") or error($PN.'20');
-			$row = mysql_fetch_array($result);
+			$result = mysqli_query($con, "SELECT rule_id, PassOrFail, comment, last_modified FROM assessment_rules WHERE id = LAST_INSERT_ID();") or error($PN.'20', $con);
+			$row = mysqli_fetch_array($result);
 
 			$row['change_status'] = 'No';
 			$row['completed'] = 'No';
 
 			//Change New to Uncompleted in assignment Table
-			mysql_query("UPDATE assignment SET status=2 WHERE id=".$assignment_id." AND status=1;") or error($PN.'21');
+			mysqli_query($con, "UPDATE assignment SET status=2 WHERE id=".$assignment_id." AND status=1;") or error($PN.'21', $con);
 
-			$result_chapter = mysql_query("SELECT chapter_id FROM rules WHERE id =".$rule_id.";") or error($PN.'22');
-			$array_chapter = mysql_fetch_array($result_chapter);
+			$result_chapter = mysqli_query($con, "SELECT chapter_id FROM rules WHERE id =".$rule_id.";") or error($PN.'22', $con);
+			$array_chapter = mysqli_fetch_array($result_chapter);
 			
 			//Change New to Uncompleted in assignment_chapter Table
-			mysql_query("UPDATE assignment_chapter SET status=2 WHERE assignment_id=".$assignment_id." AND chapter_id=".$array_chapter['chapter_id']." AND status=1;") or error($PN.'32');			
+			mysqli_query($con, "UPDATE assignment_chapter SET status=2 WHERE assignment_id=".$assignment_id." AND chapter_id=".$array_chapter['chapter_id']." AND status=1;") or error($PN.'32', $con);
 
-			if(mysql_affected_rows() == 1)
+			if(mysqli_affected_rows($con)  == 1)
 			{
 				$row['change_status'] = 'Yes';
 			}
 			
-			$result_count1 = mysql_query("SELECT COUNT(*) FROM rules WHERE chapter_id =".$array_chapter['chapter_id'].";") or error($PN.'23');
-			$array_count1 = mysql_fetch_array($result_count1);
+			$result_count1 = mysqli_query($con, "SELECT COUNT(*) FROM rules WHERE chapter_id =".$array_chapter['chapter_id'].";") or error($PN.'23', $con);
+			$array_count1 = mysqli_fetch_array($result_count1);
 
-			$result_count2 = mysql_query("SELECT COUNT(*) FROM assessment_rules WHERE assignment_id=".$assignment_id." AND rule_id IN (SELECT id FROM rules WHERE chapter_id =".$array_chapter['chapter_id'].");") or error($PN.'24');
-			$array_count2 = mysql_fetch_array($result_count2);
+			$result_count2 = mysqli_query($con, "SELECT COUNT(*) FROM assessment_rules WHERE assignment_id=".$assignment_id." AND rule_id IN (SELECT id FROM rules WHERE chapter_id =".$array_chapter['chapter_id'].");") or error($PN.'24', $con);
+			$array_count2 = mysqli_fetch_array($result_count2);
 			
 			//Set status=3 in assignment_chapter Table
 			if($array_count1[0] == $array_count2[0])
 			{
-				mysql_query("UPDATE assignment_chapter SET status=3 WHERE assignment_id=".$assignment_id." AND chapter_id=".$array_chapter['chapter_id'].";") or error($PN.'25');
-				if(mysql_affected_rows() == 1)
+				mysqli_query($con, "UPDATE assignment_chapter SET status=3 WHERE assignment_id=".$assignment_id." AND chapter_id=".$array_chapter['chapter_id'].";") or error($PN.'25', $con);
+				if(mysqli_affected_rows($con)  == 1)
 				{
 					$row['change_status'] = 'Yes';
 				}
 			}
 
 			//Change Uncompleted to Completed in assignment Table
-			$result3 = mysql_query("SELECT COUNT(*) FROM assignment_chapter WHERE assignment_id=".$assignment_id." and status!=3;") or error($PN.'26');
-			$array3 = mysql_fetch_array($result3);
+			$result3 = mysqli_query($con, "SELECT COUNT(*) FROM assignment_chapter WHERE assignment_id=".$assignment_id." and status!=3;") or error($PN.'26', $con);
+			$array3 = mysqli_fetch_array($result3);
 			if($array3[0] == 0)
 			{
-				mysql_query("UPDATE assignment SET status=3 WHERE id=".$assignment_id." AND status=2;") or error($PN.'27');
+				mysqli_query($con, "UPDATE assignment SET status=3 WHERE id=".$assignment_id." AND status=2;") or error($PN.'27', $con);
 				$row['completed'] = 'Yes';
 			}
 
 			//Set Complete=1 in assessment Table
-			$result4 = mysql_query("SELECT assessment_id FROM assignment WHERE id=".$assignment_id.";") or error($PN.'28');
-			$array4 = mysql_fetch_array($result4);
+			$result4 = mysqli_query($con, "SELECT assessment_id FROM assignment WHERE id=".$assignment_id.";") or error($PN.'28', $con);
+			$array4 = mysqli_fetch_array($result4);
 
-			$result5 = mysql_query("SELECT COUNT(*) FROM assignment WHERE assessment_id=".$array4[0]." AND status!=3;") or error($PN.'29');
-			$array5 = mysql_fetch_array($result5);
+			$result5 = mysqli_query($con, "SELECT COUNT(*) FROM assignment WHERE assessment_id=".$array4[0]." AND status!=3;") or error($PN.'29', $con);
+			$array5 = mysqli_fetch_array($result5);
 			if($array5[0] == 0)
-				mysql_query("UPDATE assessment SET complete=1, complete_time= NOW() WHERE id=".$array4[0].";") or error($PN.'30');
+				mysqli_query($con, "UPDATE assessment SET complete=1, complete_time= NOW() WHERE id=".$array4[0].";") or error($PN.'30', $con);
 		}
 	}
 	else
-		error($PN.'31');
+		error($PN.'31', $con);
 
 	$response = array();
 	$response['Result'] = "OK";
 	$response['Record'] = $row;
 	print json_encode($response);
 
-	@mysql_close();
+	@mysqli_close($con) ;
 ?>


### PR DESCRIPTION
Just updated this to be PHP7 friendly by changing all the mysql_ calls to mysqli_ ones.
I adjusted this for the new syntax where you can't rely on a global shared connection state anymore and pass the connection handle along if neccessary.